### PR TITLE
Fix yaml warnings

### DIFF
--- a/wcxf/classes.py
+++ b/wcxf/classes.py
@@ -36,7 +36,7 @@ def _load_yaml_json(stream, **kwargs):
     try:
         return json.loads(ss, **kwargs)
     except ValueError:
-        return yaml.load(ss, **kwargs)
+        return yaml.load(ss, Loader=yaml.FullLoader, **kwargs)
 
 def _dump_json(d, stream=None, **kwargs):
     """Dump to a JSON string (if `stream` is None) or stream."""
@@ -46,7 +46,7 @@ def _dump_json(d, stream=None, **kwargs):
         return json.dumps(d, **kwargs)
 
 def _yaml_to_json(stream_in, stream_out, **kwargs):
-    d = yaml.load(stream_in)
+    d = yaml.load(stream_in, Loader=yaml.FullLoader)
     return _dump_json(d, stream_out, **kwargs)
 
 def _json_to_yaml(stream_in, stream_out, **kwargs):

--- a/wcxf/converters/dsixtools.py
+++ b/wcxf/converters/dsixtools.py
@@ -21,7 +21,7 @@ def load(stream, fmt='lha'):
         else:
             return json.load(stream)
     elif fmt == 'yaml':
-        return yaml.load(stream)
+        return yaml.load(stream, Loader=yaml.FullLoader)
 
 def lha2matrix(values, shape):
     """Return a matrix given a list of values of the form

--- a/wcxf/converters/eos.py
+++ b/wcxf/converters/eos.py
@@ -14,7 +14,7 @@ def get_sm_wcs(eos_parameter_dir):
     yamlfiles = glob.glob(os.path.join(eos_parameter_dir, '*.yaml'))
     for yamlfile in yamlfiles:
         with open(yamlfile, 'r') as f:
-            wcs = yaml.load(f)
+            wcs = yaml.load(f, Loader=yaml.FullLoader)
         meta = wcs.get('@metadata@', {})
         if 'wcxf-relevant' in meta and meta['wcxf-relevant']:
             del wcs['@metadata@']

--- a/wcxf/test_cli.py
+++ b/wcxf/test_cli.py
@@ -20,7 +20,7 @@ def _del_files(fs):
 class TestCLI(unittest.TestCase):
     def test_convert(self):
         yml1 = pkgutil.get_data('wcxf', 'data/test.basis1.yml').decode('utf-8')
-        d_yml1 = yaml.load(yml1)
+        d_yml1 = yaml.load(yml1, Loader=yaml.FullLoader)
         # YAML stdin -> JSON stdout
         res = subprocess.run(['wcxf', 'convert', 'json', '-'],
                              input=yml1.encode(),
@@ -33,7 +33,7 @@ class TestCLI(unittest.TestCase):
                              input=json1.encode(),
                              stdout=subprocess.PIPE)
         yml2 = res.stdout.decode('utf-8')
-        d_yml2 = yaml.load(yml2)
+        d_yml2 = yaml.load(yml2, Loader=yaml.FullLoader)
         self.assertDictEqual(d_json1, d_yml2)
         # YAML file -> JSON file
         _, fin = tempfile.mkstemp()
@@ -54,7 +54,7 @@ class TestCLI(unittest.TestCase):
         res = subprocess.run(['wcxf', 'convert', 'yaml', fin, '--output', fout])
         with open(fout, 'r') as f:
             yml3 = f.read()
-        d_yml3 = yaml.load(yml3)
+        d_yml3 = yaml.load(yml3, Loader=yaml.FullLoader)
         self.assertDictEqual(d_yml3, d_json1)
         # delete temp files
         _del_files([fin, fout])


### PR DESCRIPTION
Get rid of the deprecration warning explained here:
https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

This pull request relates to the PR @ https://github.com/flav-io/flavio/pull/87

The fix is minimal invasive. It explicitly performes what is done implicitly up until now, getting rid of the warning.

Cheers,
Markus