### PR TITLE
First version of SmeftFR converter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(name='wcxf',
             'wcxf2dsixtools = wcxf.cli:wcxf2dsixtools',
             'dsixtools2wcxf = wcxf.cli:dsixtools2wcxf',
             'wcxf2smeftsim = wcxf.cli:smeftsim',
+            'wcxf2smeftfr = wcxf.cli:wcxf2smeftfr',
         ]
       },
     )

--- a/wcxf/cli.py
+++ b/wcxf/cli.py
@@ -222,3 +222,18 @@ def dsixtools2wcxf():
     args = parser.parse_args()
     dsixtools.dsixtools2wcxf(tuple(f for f in args.FILE), stream=args.output)
     return 0
+
+
+def wcxf2smeftfr():
+    from wcxf.converters import smeftfr
+    parser = argparse.ArgumentParser(description="""Command line script to convert a WCxf file to a MadGraph param_card file for SmeftFR.""",
+                                     formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument("FILE", nargs='?', help="Input file. If \"-\", read from standard input",
+                        type=argparse.FileType('r'), default=sys.stdin)
+    parser.add_argument("--output", nargs='?', help="Output file. If absent, print to standard output",
+                        type=argparse.FileType('w'), default=sys.stdout)
+    args = parser.parse_args()
+    wc = wcxf.WC.load(args.FILE)
+    wc.validate()
+    smeftfr.wcxf2smeftfr(wc, stream=args.output)
+    return 0

--- a/wcxf/converters/smeftfr.py
+++ b/wcxf/converters/smeftfr.py
@@ -1,0 +1,45 @@
+import pylha
+import json
+import pkgutil
+from wilson.util import smeftutil
+
+
+smeftfr_info = json.loads(
+    pkgutil.get_data('wcxf', 'data/smeftfr_block_info.json').decode('utf-8')
+)
+
+
+def wcxf2smeftfr_dict(wc):
+    """Take a WC instance and turn it into a dictionary suitable for producing
+    and LHA file for SmeftFR using pylha."""
+    # go from flat dict to dict of arrays, symmetrizing them
+    C = smeftutil.wcxf2arrays_symmetrized(wc.dict)
+    # go back to flat dict but keeping non-redundant WCs an symm. fac.s
+    d = smeftutil.arrays2wcxf(C)
+    # rearrange to dict in right format for SmeftFR
+    card = {}
+    for block_name, block in smeftfr_info.items():
+        card[block_name] = {'values': []}
+        for info in block:
+            line = [*info['index'], d[info['coeff']].real, info['comment']]
+            card[block_name]['values'].append(line)
+    return card
+
+
+def wcxf2smeftfr(wc, stream):
+    """Take a WC instance and dump it into an LHA file (or return as string)
+    in a format suitable for use as `param_card.dat` file for MadGraph
+    with SmeftFR
+    """
+    if (wc.eft, wc.basis) == ('SMEFT', 'Warsaw mass'):
+        wc_m = wc
+    else:
+        if wc.eft != 'SMEFT':
+            raise ValueError("wcxf2smeftfr only support SMEFT Wilson coefficients")
+        else:
+            try:
+                wc_m = wc.translate('Warsaw mass')
+            except ValueError:
+                raise ValueError("wcxf2smeftfr requires a basis that can be translated to the Warsaw mass basis")
+    return pylha.dump({'BLOCK': wcxf2smeftfr_dict(wc_m)},
+                      fmt='lha', stream=stream)

--- a/wcxf/data/smeftfr_block_info.json
+++ b/wcxf/data/smeftfr_block_info.json
@@ -1,0 +1,25130 @@
+{
+  "frblock": [
+    {
+      "index": [
+        26
+      ],
+      "coeff": "G",
+      "comment": "# CG "
+    },
+    {
+      "index": [
+        27
+      ],
+      "coeff": "Gtilde",
+      "comment": "# CGtilde "
+    },
+    {
+      "index": [
+        28
+      ],
+      "coeff": "phi",
+      "comment": "# Cphi "
+    },
+    {
+      "index": [
+        29
+      ],
+      "coeff": "phiB",
+      "comment": "# CphiB "
+    },
+    {
+      "index": [
+        30
+      ],
+      "coeff": "phiBox",
+      "comment": "# CphiBox "
+    },
+    {
+      "index": [
+        31
+      ],
+      "coeff": "phiBtilde",
+      "comment": "# CphiBtilde "
+    },
+    {
+      "index": [
+        32
+      ],
+      "coeff": "phiD",
+      "comment": "# CphiD "
+    },
+    {
+      "index": [
+        33
+      ],
+      "coeff": "phiG",
+      "comment": "# CphiG "
+    },
+    {
+      "index": [
+        34
+      ],
+      "coeff": "phiGtilde",
+      "comment": "# CphiGtilde "
+    },
+    {
+      "index": [
+        35
+      ],
+      "coeff": "phiW",
+      "comment": "# CphiW "
+    },
+    {
+      "index": [
+        36
+      ],
+      "coeff": "phiWB",
+      "comment": "# CphiWB "
+    },
+    {
+      "index": [
+        37
+      ],
+      "coeff": "phiWtilde",
+      "comment": "# CphiWtilde "
+    },
+    {
+      "index": [
+        38
+      ],
+      "coeff": "phiWtildeB",
+      "comment": "# CphiWtildeB "
+    },
+    {
+      "index": [
+        40
+      ],
+      "coeff": "Wtilde",
+      "comment": "# CWtilde "
+    }
+  ],
+  "frblock10": [
+    {
+      "index": [
+        1,
+        1
+      ],
+      "coeff": "eW_11",
+      "comment": "# CeW1x1 "
+    },
+    {
+      "index": [
+        1,
+        2
+      ],
+      "coeff": "eW_12",
+      "comment": "# CeW1x2 "
+    },
+    {
+      "index": [
+        1,
+        3
+      ],
+      "coeff": "eW_13",
+      "comment": "# CeW1x3 "
+    },
+    {
+      "index": [
+        2,
+        1
+      ],
+      "coeff": "eW_21",
+      "comment": "# CeW2x1 "
+    },
+    {
+      "index": [
+        2,
+        2
+      ],
+      "coeff": "eW_22",
+      "comment": "# CeW2x2 "
+    },
+    {
+      "index": [
+        2,
+        3
+      ],
+      "coeff": "eW_23",
+      "comment": "# CeW2x3 "
+    },
+    {
+      "index": [
+        3,
+        1
+      ],
+      "coeff": "eW_31",
+      "comment": "# CeW3x1 "
+    },
+    {
+      "index": [
+        3,
+        2
+      ],
+      "coeff": "eW_32",
+      "comment": "# CeW3x2 "
+    },
+    {
+      "index": [
+        3,
+        3
+      ],
+      "coeff": "eW_33",
+      "comment": "# CeW3x3 "
+    }
+  ],
+  "frblock11": [
+    {
+      "index": [
+        1,
+        1
+      ],
+      "coeff": "phid_11",
+      "comment": "# Cphid1x1 "
+    },
+    {
+      "index": [
+        1,
+        2
+      ],
+      "coeff": "phid_12",
+      "comment": "# Cphid1x2 "
+    },
+    {
+      "index": [
+        1,
+        3
+      ],
+      "coeff": "phid_13",
+      "comment": "# Cphid1x3 "
+    },
+    {
+      "index": [
+        2,
+        1
+      ],
+      "coeff": "phid_21",
+      "comment": "# Cphid2x1 "
+    },
+    {
+      "index": [
+        2,
+        2
+      ],
+      "coeff": "phid_22",
+      "comment": "# Cphid2x2 "
+    },
+    {
+      "index": [
+        2,
+        3
+      ],
+      "coeff": "phid_23",
+      "comment": "# Cphid2x3 "
+    },
+    {
+      "index": [
+        3,
+        1
+      ],
+      "coeff": "phid_31",
+      "comment": "# Cphid3x1 "
+    },
+    {
+      "index": [
+        3,
+        2
+      ],
+      "coeff": "phid_32",
+      "comment": "# Cphid3x2 "
+    },
+    {
+      "index": [
+        3,
+        3
+      ],
+      "coeff": "phid_33",
+      "comment": "# Cphid3x3 "
+    }
+  ],
+  "frblock12": [
+    {
+      "index": [
+        1,
+        1
+      ],
+      "coeff": "phie_11",
+      "comment": "# Cphie1x1 "
+    },
+    {
+      "index": [
+        1,
+        2
+      ],
+      "coeff": "phie_12",
+      "comment": "# Cphie1x2 "
+    },
+    {
+      "index": [
+        1,
+        3
+      ],
+      "coeff": "phie_13",
+      "comment": "# Cphie1x3 "
+    },
+    {
+      "index": [
+        2,
+        1
+      ],
+      "coeff": "phie_21",
+      "comment": "# Cphie2x1 "
+    },
+    {
+      "index": [
+        2,
+        2
+      ],
+      "coeff": "phie_22",
+      "comment": "# Cphie2x2 "
+    },
+    {
+      "index": [
+        2,
+        3
+      ],
+      "coeff": "phie_23",
+      "comment": "# Cphie2x3 "
+    },
+    {
+      "index": [
+        3,
+        1
+      ],
+      "coeff": "phie_31",
+      "comment": "# Cphie3x1 "
+    },
+    {
+      "index": [
+        3,
+        2
+      ],
+      "coeff": "phie_32",
+      "comment": "# Cphie3x2 "
+    },
+    {
+      "index": [
+        3,
+        3
+      ],
+      "coeff": "phie_33",
+      "comment": "# Cphie3x3 "
+    }
+  ],
+  "frblock13": [
+    {
+      "index": [
+        1,
+        1
+      ],
+      "coeff": "phil1_11",
+      "comment": "# Cphil11x1 "
+    },
+    {
+      "index": [
+        1,
+        2
+      ],
+      "coeff": "phil1_12",
+      "comment": "# Cphil11x2 "
+    },
+    {
+      "index": [
+        1,
+        3
+      ],
+      "coeff": "phil1_13",
+      "comment": "# Cphil11x3 "
+    },
+    {
+      "index": [
+        2,
+        1
+      ],
+      "coeff": "phil1_21",
+      "comment": "# Cphil12x1 "
+    },
+    {
+      "index": [
+        2,
+        2
+      ],
+      "coeff": "phil1_22",
+      "comment": "# Cphil12x2 "
+    },
+    {
+      "index": [
+        2,
+        3
+      ],
+      "coeff": "phil1_23",
+      "comment": "# Cphil12x3 "
+    },
+    {
+      "index": [
+        3,
+        1
+      ],
+      "coeff": "phil1_31",
+      "comment": "# Cphil13x1 "
+    },
+    {
+      "index": [
+        3,
+        2
+      ],
+      "coeff": "phil1_32",
+      "comment": "# Cphil13x2 "
+    },
+    {
+      "index": [
+        3,
+        3
+      ],
+      "coeff": "phil1_33",
+      "comment": "# Cphil13x3 "
+    }
+  ],
+  "frblock14": [
+    {
+      "index": [
+        1,
+        1
+      ],
+      "coeff": "phil3_11",
+      "comment": "# Cphil31x1 "
+    },
+    {
+      "index": [
+        1,
+        2
+      ],
+      "coeff": "phil3_12",
+      "comment": "# Cphil31x2 "
+    },
+    {
+      "index": [
+        1,
+        3
+      ],
+      "coeff": "phil3_13",
+      "comment": "# Cphil31x3 "
+    },
+    {
+      "index": [
+        2,
+        1
+      ],
+      "coeff": "phil3_21",
+      "comment": "# Cphil32x1 "
+    },
+    {
+      "index": [
+        2,
+        2
+      ],
+      "coeff": "phil3_22",
+      "comment": "# Cphil32x2 "
+    },
+    {
+      "index": [
+        2,
+        3
+      ],
+      "coeff": "phil3_23",
+      "comment": "# Cphil32x3 "
+    },
+    {
+      "index": [
+        3,
+        1
+      ],
+      "coeff": "phil3_31",
+      "comment": "# Cphil33x1 "
+    },
+    {
+      "index": [
+        3,
+        2
+      ],
+      "coeff": "phil3_32",
+      "comment": "# Cphil33x2 "
+    },
+    {
+      "index": [
+        3,
+        3
+      ],
+      "coeff": "phil3_33",
+      "comment": "# Cphil33x3 "
+    }
+  ],
+  "frblock15": [
+    {
+      "index": [
+        1,
+        1
+      ],
+      "coeff": "phiq1_11",
+      "comment": "# Cphiq11x1 "
+    },
+    {
+      "index": [
+        1,
+        2
+      ],
+      "coeff": "phiq1_12",
+      "comment": "# Cphiq11x2 "
+    },
+    {
+      "index": [
+        1,
+        3
+      ],
+      "coeff": "phiq1_13",
+      "comment": "# Cphiq11x3 "
+    },
+    {
+      "index": [
+        2,
+        1
+      ],
+      "coeff": "phiq1_21",
+      "comment": "# Cphiq12x1 "
+    },
+    {
+      "index": [
+        2,
+        2
+      ],
+      "coeff": "phiq1_22",
+      "comment": "# Cphiq12x2 "
+    },
+    {
+      "index": [
+        2,
+        3
+      ],
+      "coeff": "phiq1_23",
+      "comment": "# Cphiq12x3 "
+    },
+    {
+      "index": [
+        3,
+        1
+      ],
+      "coeff": "phiq1_31",
+      "comment": "# Cphiq13x1 "
+    },
+    {
+      "index": [
+        3,
+        2
+      ],
+      "coeff": "phiq1_32",
+      "comment": "# Cphiq13x2 "
+    },
+    {
+      "index": [
+        3,
+        3
+      ],
+      "coeff": "phiq1_33",
+      "comment": "# Cphiq13x3 "
+    }
+  ],
+  "frblock16": [
+    {
+      "index": [
+        1,
+        1
+      ],
+      "coeff": "phiq3_11",
+      "comment": "# Cphiq31x1 "
+    },
+    {
+      "index": [
+        1,
+        2
+      ],
+      "coeff": "phiq3_12",
+      "comment": "# Cphiq31x2 "
+    },
+    {
+      "index": [
+        1,
+        3
+      ],
+      "coeff": "phiq3_13",
+      "comment": "# Cphiq31x3 "
+    },
+    {
+      "index": [
+        2,
+        1
+      ],
+      "coeff": "phiq3_21",
+      "comment": "# Cphiq32x1 "
+    },
+    {
+      "index": [
+        2,
+        2
+      ],
+      "coeff": "phiq3_22",
+      "comment": "# Cphiq32x2 "
+    },
+    {
+      "index": [
+        2,
+        3
+      ],
+      "coeff": "phiq3_23",
+      "comment": "# Cphiq32x3 "
+    },
+    {
+      "index": [
+        3,
+        1
+      ],
+      "coeff": "phiq3_31",
+      "comment": "# Cphiq33x1 "
+    },
+    {
+      "index": [
+        3,
+        2
+      ],
+      "coeff": "phiq3_32",
+      "comment": "# Cphiq33x2 "
+    },
+    {
+      "index": [
+        3,
+        3
+      ],
+      "coeff": "phiq3_33",
+      "comment": "# Cphiq33x3 "
+    }
+  ],
+  "frblock17": [
+    {
+      "index": [
+        1,
+        1
+      ],
+      "coeff": "phiu_11",
+      "comment": "# Cphiu1x1 "
+    },
+    {
+      "index": [
+        1,
+        2
+      ],
+      "coeff": "phiu_12",
+      "comment": "# Cphiu1x2 "
+    },
+    {
+      "index": [
+        1,
+        3
+      ],
+      "coeff": "phiu_13",
+      "comment": "# Cphiu1x3 "
+    },
+    {
+      "index": [
+        2,
+        1
+      ],
+      "coeff": "phiu_21",
+      "comment": "# Cphiu2x1 "
+    },
+    {
+      "index": [
+        2,
+        2
+      ],
+      "coeff": "phiu_22",
+      "comment": "# Cphiu2x2 "
+    },
+    {
+      "index": [
+        2,
+        3
+      ],
+      "coeff": "phiu_23",
+      "comment": "# Cphiu2x3 "
+    },
+    {
+      "index": [
+        3,
+        1
+      ],
+      "coeff": "phiu_31",
+      "comment": "# Cphiu3x1 "
+    },
+    {
+      "index": [
+        3,
+        2
+      ],
+      "coeff": "phiu_32",
+      "comment": "# Cphiu3x2 "
+    },
+    {
+      "index": [
+        3,
+        3
+      ],
+      "coeff": "phiu_33",
+      "comment": "# Cphiu3x3 "
+    }
+  ],
+  "frblock18": [
+    {
+      "index": [
+        1,
+        1
+      ],
+      "coeff": "phiud_11",
+      "comment": "# Cphiud1x1 "
+    },
+    {
+      "index": [
+        1,
+        2
+      ],
+      "coeff": "phiud_12",
+      "comment": "# Cphiud1x2 "
+    },
+    {
+      "index": [
+        1,
+        3
+      ],
+      "coeff": "phiud_13",
+      "comment": "# Cphiud1x3 "
+    },
+    {
+      "index": [
+        2,
+        1
+      ],
+      "coeff": "phiud_21",
+      "comment": "# Cphiud2x1 "
+    },
+    {
+      "index": [
+        2,
+        2
+      ],
+      "coeff": "phiud_22",
+      "comment": "# Cphiud2x2 "
+    },
+    {
+      "index": [
+        2,
+        3
+      ],
+      "coeff": "phiud_23",
+      "comment": "# Cphiud2x3 "
+    },
+    {
+      "index": [
+        3,
+        1
+      ],
+      "coeff": "phiud_31",
+      "comment": "# Cphiud3x1 "
+    },
+    {
+      "index": [
+        3,
+        2
+      ],
+      "coeff": "phiud_32",
+      "comment": "# Cphiud3x2 "
+    },
+    {
+      "index": [
+        3,
+        3
+      ],
+      "coeff": "phiud_33",
+      "comment": "# Cphiud3x3 "
+    }
+  ],
+  "frblock19": [
+    {
+      "index": [
+        1,
+        1
+      ],
+      "coeff": "uB_11",
+      "comment": "# CuB1x1 "
+    },
+    {
+      "index": [
+        1,
+        2
+      ],
+      "coeff": "uB_12",
+      "comment": "# CuB1x2 "
+    },
+    {
+      "index": [
+        1,
+        3
+      ],
+      "coeff": "uB_13",
+      "comment": "# CuB1x3 "
+    },
+    {
+      "index": [
+        2,
+        1
+      ],
+      "coeff": "uB_21",
+      "comment": "# CuB2x1 "
+    },
+    {
+      "index": [
+        2,
+        2
+      ],
+      "coeff": "uB_22",
+      "comment": "# CuB2x2 "
+    },
+    {
+      "index": [
+        2,
+        3
+      ],
+      "coeff": "uB_23",
+      "comment": "# CuB2x3 "
+    },
+    {
+      "index": [
+        3,
+        1
+      ],
+      "coeff": "uB_31",
+      "comment": "# CuB3x1 "
+    },
+    {
+      "index": [
+        3,
+        2
+      ],
+      "coeff": "uB_32",
+      "comment": "# CuB3x2 "
+    },
+    {
+      "index": [
+        3,
+        3
+      ],
+      "coeff": "uB_33",
+      "comment": "# CuB3x3 "
+    }
+  ],
+  "frblock20": [
+    {
+      "index": [
+        1,
+        1
+      ],
+      "coeff": "uG_11",
+      "comment": "# CuG1x1 "
+    },
+    {
+      "index": [
+        1,
+        2
+      ],
+      "coeff": "uG_12",
+      "comment": "# CuG1x2 "
+    },
+    {
+      "index": [
+        1,
+        3
+      ],
+      "coeff": "uG_13",
+      "comment": "# CuG1x3 "
+    },
+    {
+      "index": [
+        2,
+        1
+      ],
+      "coeff": "uG_21",
+      "comment": "# CuG2x1 "
+    },
+    {
+      "index": [
+        2,
+        2
+      ],
+      "coeff": "uG_22",
+      "comment": "# CuG2x2 "
+    },
+    {
+      "index": [
+        2,
+        3
+      ],
+      "coeff": "uG_23",
+      "comment": "# CuG2x3 "
+    },
+    {
+      "index": [
+        3,
+        1
+      ],
+      "coeff": "uG_31",
+      "comment": "# CuG3x1 "
+    },
+    {
+      "index": [
+        3,
+        2
+      ],
+      "coeff": "uG_32",
+      "comment": "# CuG3x2 "
+    },
+    {
+      "index": [
+        3,
+        3
+      ],
+      "coeff": "uG_33",
+      "comment": "# CuG3x3 "
+    }
+  ],
+  "frblock21": [
+    {
+      "index": [
+        1,
+        1
+      ],
+      "coeff": "uphi_11",
+      "comment": "# Cuphi1x1 "
+    },
+    {
+      "index": [
+        1,
+        2
+      ],
+      "coeff": "uphi_12",
+      "comment": "# Cuphi1x2 "
+    },
+    {
+      "index": [
+        1,
+        3
+      ],
+      "coeff": "uphi_13",
+      "comment": "# Cuphi1x3 "
+    },
+    {
+      "index": [
+        2,
+        1
+      ],
+      "coeff": "uphi_21",
+      "comment": "# Cuphi2x1 "
+    },
+    {
+      "index": [
+        2,
+        2
+      ],
+      "coeff": "uphi_22",
+      "comment": "# Cuphi2x2 "
+    },
+    {
+      "index": [
+        2,
+        3
+      ],
+      "coeff": "uphi_23",
+      "comment": "# Cuphi2x3 "
+    },
+    {
+      "index": [
+        3,
+        1
+      ],
+      "coeff": "uphi_31",
+      "comment": "# Cuphi3x1 "
+    },
+    {
+      "index": [
+        3,
+        2
+      ],
+      "coeff": "uphi_32",
+      "comment": "# Cuphi3x2 "
+    },
+    {
+      "index": [
+        3,
+        3
+      ],
+      "coeff": "uphi_33",
+      "comment": "# Cuphi3x3 "
+    }
+  ],
+  "frblock22": [
+    {
+      "index": [
+        1,
+        1
+      ],
+      "coeff": "uW_11",
+      "comment": "# CuW1x1 "
+    },
+    {
+      "index": [
+        1,
+        2
+      ],
+      "coeff": "uW_12",
+      "comment": "# CuW1x2 "
+    },
+    {
+      "index": [
+        1,
+        3
+      ],
+      "coeff": "uW_13",
+      "comment": "# CuW1x3 "
+    },
+    {
+      "index": [
+        2,
+        1
+      ],
+      "coeff": "uW_21",
+      "comment": "# CuW2x1 "
+    },
+    {
+      "index": [
+        2,
+        2
+      ],
+      "coeff": "uW_22",
+      "comment": "# CuW2x2 "
+    },
+    {
+      "index": [
+        2,
+        3
+      ],
+      "coeff": "uW_23",
+      "comment": "# CuW2x3 "
+    },
+    {
+      "index": [
+        3,
+        1
+      ],
+      "coeff": "uW_31",
+      "comment": "# CuW3x1 "
+    },
+    {
+      "index": [
+        3,
+        2
+      ],
+      "coeff": "uW_32",
+      "comment": "# CuW3x2 "
+    },
+    {
+      "index": [
+        3,
+        3
+      ],
+      "coeff": "uW_33",
+      "comment": "# CuW3x3 "
+    }
+  ],
+  "frblock23": [
+    {
+      "index": [
+        1,
+        1
+      ],
+      "coeff": "llphiphi_11",
+      "comment": "# Cvv1x1 "
+    },
+    {
+      "index": [
+        1,
+        2
+      ],
+      "coeff": "llphiphi_12",
+      "comment": "# Cvv1x2 "
+    },
+    {
+      "index": [
+        1,
+        3
+      ],
+      "coeff": "llphiphi_13",
+      "comment": "# Cvv1x3 "
+    },
+    {
+      "index": [
+        2,
+        1
+      ],
+      "coeff": "llphiphi_21",
+      "comment": "# Cvv2x1 "
+    },
+    {
+      "index": [
+        2,
+        2
+      ],
+      "coeff": "llphiphi_22",
+      "comment": "# Cvv2x2 "
+    },
+    {
+      "index": [
+        2,
+        3
+      ],
+      "coeff": "llphiphi_23",
+      "comment": "# Cvv2x3 "
+    },
+    {
+      "index": [
+        3,
+        1
+      ],
+      "coeff": "llphiphi_31",
+      "comment": "# Cvv3x1 "
+    },
+    {
+      "index": [
+        3,
+        2
+      ],
+      "coeff": "llphiphi_32",
+      "comment": "# Cvv3x2 "
+    },
+    {
+      "index": [
+        3,
+        3
+      ],
+      "coeff": "llphiphi_33",
+      "comment": "# Cvv3x3 "
+    }
+  ],
+  "frblock24": [
+    {
+      "index": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "coeff": "dd_1111",
+      "comment": "# Cdd1x1x1x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        2
+      ],
+      "coeff": "dd_1112",
+      "comment": "# Cdd1x1x1x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        3
+      ],
+      "coeff": "dd_1113",
+      "comment": "# Cdd1x1x1x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        1
+      ],
+      "coeff": "dd_1121",
+      "comment": "# Cdd1x1x2x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "coeff": "dd_1122",
+      "comment": "# Cdd1x1x2x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "coeff": "dd_1123",
+      "comment": "# Cdd1x1x2x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        1
+      ],
+      "coeff": "dd_1131",
+      "comment": "# Cdd1x1x3x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        2
+      ],
+      "coeff": "dd_1132",
+      "comment": "# Cdd1x1x3x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        3
+      ],
+      "coeff": "dd_1133",
+      "comment": "# Cdd1x1x3x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        1
+      ],
+      "coeff": "dd_1211",
+      "comment": "# Cdd1x2x1x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        2
+      ],
+      "coeff": "dd_1212",
+      "comment": "# Cdd1x2x1x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        3
+      ],
+      "coeff": "dd_1213",
+      "comment": "# Cdd1x2x1x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        1
+      ],
+      "coeff": "dd_1221",
+      "comment": "# Cdd1x2x2x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        2
+      ],
+      "coeff": "dd_1222",
+      "comment": "# Cdd1x2x2x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        3
+      ],
+      "coeff": "dd_1223",
+      "comment": "# Cdd1x2x2x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        1
+      ],
+      "coeff": "dd_1231",
+      "comment": "# Cdd1x2x3x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        2
+      ],
+      "coeff": "dd_1232",
+      "comment": "# Cdd1x2x3x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        3
+      ],
+      "coeff": "dd_1233",
+      "comment": "# Cdd1x2x3x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        1
+      ],
+      "coeff": "dd_1311",
+      "comment": "# Cdd1x3x1x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        2
+      ],
+      "coeff": "dd_1312",
+      "comment": "# Cdd1x3x1x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        3
+      ],
+      "coeff": "dd_1313",
+      "comment": "# Cdd1x3x1x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        1
+      ],
+      "coeff": "dd_1321",
+      "comment": "# Cdd1x3x2x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        2
+      ],
+      "coeff": "dd_1322",
+      "comment": "# Cdd1x3x2x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        3
+      ],
+      "coeff": "dd_1323",
+      "comment": "# Cdd1x3x2x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        1
+      ],
+      "coeff": "dd_1331",
+      "comment": "# Cdd1x3x3x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        2
+      ],
+      "coeff": "dd_1332",
+      "comment": "# Cdd1x3x3x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        3
+      ],
+      "coeff": "dd_1333",
+      "comment": "# Cdd1x3x3x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "coeff": "dd_2111",
+      "comment": "# Cdd2x1x1x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        2
+      ],
+      "coeff": "dd_2112",
+      "comment": "# Cdd2x1x1x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        3
+      ],
+      "coeff": "dd_2113",
+      "comment": "# Cdd2x1x1x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "coeff": "dd_2121",
+      "comment": "# Cdd2x1x2x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        2
+      ],
+      "coeff": "dd_2122",
+      "comment": "# Cdd2x1x2x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "coeff": "dd_2123",
+      "comment": "# Cdd2x1x2x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        1
+      ],
+      "coeff": "dd_2131",
+      "comment": "# Cdd2x1x3x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        2
+      ],
+      "coeff": "dd_2132",
+      "comment": "# Cdd2x1x3x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        3
+      ],
+      "coeff": "dd_2133",
+      "comment": "# Cdd2x1x3x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        1
+      ],
+      "coeff": "dd_2211",
+      "comment": "# Cdd2x2x1x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        2
+      ],
+      "coeff": "dd_2212",
+      "comment": "# Cdd2x2x1x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        3
+      ],
+      "coeff": "dd_2213",
+      "comment": "# Cdd2x2x1x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        1
+      ],
+      "coeff": "dd_2221",
+      "comment": "# Cdd2x2x2x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "coeff": "dd_2222",
+      "comment": "# Cdd2x2x2x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        3
+      ],
+      "coeff": "dd_2223",
+      "comment": "# Cdd2x2x2x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        1
+      ],
+      "coeff": "dd_2231",
+      "comment": "# Cdd2x2x3x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        2
+      ],
+      "coeff": "dd_2232",
+      "comment": "# Cdd2x2x3x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        3
+      ],
+      "coeff": "dd_2233",
+      "comment": "# Cdd2x2x3x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        1
+      ],
+      "coeff": "dd_2311",
+      "comment": "# Cdd2x3x1x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        2
+      ],
+      "coeff": "dd_2312",
+      "comment": "# Cdd2x3x1x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        3
+      ],
+      "coeff": "dd_2313",
+      "comment": "# Cdd2x3x1x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        1
+      ],
+      "coeff": "dd_2321",
+      "comment": "# Cdd2x3x2x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        2
+      ],
+      "coeff": "dd_2322",
+      "comment": "# Cdd2x3x2x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        3
+      ],
+      "coeff": "dd_2323",
+      "comment": "# Cdd2x3x2x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        1
+      ],
+      "coeff": "dd_2331",
+      "comment": "# Cdd2x3x3x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        2
+      ],
+      "coeff": "dd_2332",
+      "comment": "# Cdd2x3x3x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        3
+      ],
+      "coeff": "dd_2333",
+      "comment": "# Cdd2x3x3x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        1
+      ],
+      "coeff": "dd_3111",
+      "comment": "# Cdd3x1x1x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        2
+      ],
+      "coeff": "dd_3112",
+      "comment": "# Cdd3x1x1x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        3
+      ],
+      "coeff": "dd_3113",
+      "comment": "# Cdd3x1x1x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        1
+      ],
+      "coeff": "dd_3121",
+      "comment": "# Cdd3x1x2x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        2
+      ],
+      "coeff": "dd_3122",
+      "comment": "# Cdd3x1x2x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        3
+      ],
+      "coeff": "dd_3123",
+      "comment": "# Cdd3x1x2x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        1
+      ],
+      "coeff": "dd_3131",
+      "comment": "# Cdd3x1x3x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        2
+      ],
+      "coeff": "dd_3132",
+      "comment": "# Cdd3x1x3x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        3
+      ],
+      "coeff": "dd_3133",
+      "comment": "# Cdd3x1x3x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        1
+      ],
+      "coeff": "dd_3211",
+      "comment": "# Cdd3x2x1x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        2
+      ],
+      "coeff": "dd_3212",
+      "comment": "# Cdd3x2x1x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        3
+      ],
+      "coeff": "dd_3213",
+      "comment": "# Cdd3x2x1x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        1
+      ],
+      "coeff": "dd_3221",
+      "comment": "# Cdd3x2x2x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        2
+      ],
+      "coeff": "dd_3222",
+      "comment": "# Cdd3x2x2x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        3
+      ],
+      "coeff": "dd_3223",
+      "comment": "# Cdd3x2x2x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "coeff": "dd_3231",
+      "comment": "# Cdd3x2x3x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        2
+      ],
+      "coeff": "dd_3232",
+      "comment": "# Cdd3x2x3x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        3
+      ],
+      "coeff": "dd_3233",
+      "comment": "# Cdd3x2x3x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        1
+      ],
+      "coeff": "dd_3311",
+      "comment": "# Cdd3x3x1x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        2
+      ],
+      "coeff": "dd_3312",
+      "comment": "# Cdd3x3x1x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        3
+      ],
+      "coeff": "dd_3313",
+      "comment": "# Cdd3x3x1x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        1
+      ],
+      "coeff": "dd_3321",
+      "comment": "# Cdd3x3x2x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        2
+      ],
+      "coeff": "dd_3322",
+      "comment": "# Cdd3x3x2x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        3
+      ],
+      "coeff": "dd_3323",
+      "comment": "# Cdd3x3x2x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        1
+      ],
+      "coeff": "dd_3331",
+      "comment": "# Cdd3x3x3x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        2
+      ],
+      "coeff": "dd_3332",
+      "comment": "# Cdd3x3x3x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        3
+      ],
+      "coeff": "dd_3333",
+      "comment": "# Cdd3x3x3x3 "
+    }
+  ],
+  "frblock25": [
+    {
+      "index": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "coeff": "duql_1111",
+      "comment": "# Cduq1x1x1x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        2
+      ],
+      "coeff": "duql_1112",
+      "comment": "# Cduq1x1x1x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        3
+      ],
+      "coeff": "duql_1113",
+      "comment": "# Cduq1x1x1x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        1
+      ],
+      "coeff": "duql_1121",
+      "comment": "# Cduq1x1x2x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "coeff": "duql_1122",
+      "comment": "# Cduq1x1x2x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "coeff": "duql_1123",
+      "comment": "# Cduq1x1x2x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        1
+      ],
+      "coeff": "duql_1131",
+      "comment": "# Cduq1x1x3x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        2
+      ],
+      "coeff": "duql_1132",
+      "comment": "# Cduq1x1x3x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        3
+      ],
+      "coeff": "duql_1133",
+      "comment": "# Cduq1x1x3x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        1
+      ],
+      "coeff": "duql_1211",
+      "comment": "# Cduq1x2x1x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        2
+      ],
+      "coeff": "duql_1212",
+      "comment": "# Cduq1x2x1x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        3
+      ],
+      "coeff": "duql_1213",
+      "comment": "# Cduq1x2x1x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        1
+      ],
+      "coeff": "duql_1221",
+      "comment": "# Cduq1x2x2x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        2
+      ],
+      "coeff": "duql_1222",
+      "comment": "# Cduq1x2x2x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        3
+      ],
+      "coeff": "duql_1223",
+      "comment": "# Cduq1x2x2x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        1
+      ],
+      "coeff": "duql_1231",
+      "comment": "# Cduq1x2x3x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        2
+      ],
+      "coeff": "duql_1232",
+      "comment": "# Cduq1x2x3x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        3
+      ],
+      "coeff": "duql_1233",
+      "comment": "# Cduq1x2x3x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        1
+      ],
+      "coeff": "duql_1311",
+      "comment": "# Cduq1x3x1x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        2
+      ],
+      "coeff": "duql_1312",
+      "comment": "# Cduq1x3x1x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        3
+      ],
+      "coeff": "duql_1313",
+      "comment": "# Cduq1x3x1x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        1
+      ],
+      "coeff": "duql_1321",
+      "comment": "# Cduq1x3x2x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        2
+      ],
+      "coeff": "duql_1322",
+      "comment": "# Cduq1x3x2x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        3
+      ],
+      "coeff": "duql_1323",
+      "comment": "# Cduq1x3x2x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        1
+      ],
+      "coeff": "duql_1331",
+      "comment": "# Cduq1x3x3x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        2
+      ],
+      "coeff": "duql_1332",
+      "comment": "# Cduq1x3x3x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        3
+      ],
+      "coeff": "duql_1333",
+      "comment": "# Cduq1x3x3x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "coeff": "duql_2111",
+      "comment": "# Cduq2x1x1x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        2
+      ],
+      "coeff": "duql_2112",
+      "comment": "# Cduq2x1x1x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        3
+      ],
+      "coeff": "duql_2113",
+      "comment": "# Cduq2x1x1x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "coeff": "duql_2121",
+      "comment": "# Cduq2x1x2x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        2
+      ],
+      "coeff": "duql_2122",
+      "comment": "# Cduq2x1x2x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "coeff": "duql_2123",
+      "comment": "# Cduq2x1x2x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        1
+      ],
+      "coeff": "duql_2131",
+      "comment": "# Cduq2x1x3x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        2
+      ],
+      "coeff": "duql_2132",
+      "comment": "# Cduq2x1x3x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        3
+      ],
+      "coeff": "duql_2133",
+      "comment": "# Cduq2x1x3x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        1
+      ],
+      "coeff": "duql_2211",
+      "comment": "# Cduq2x2x1x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        2
+      ],
+      "coeff": "duql_2212",
+      "comment": "# Cduq2x2x1x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        3
+      ],
+      "coeff": "duql_2213",
+      "comment": "# Cduq2x2x1x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        1
+      ],
+      "coeff": "duql_2221",
+      "comment": "# Cduq2x2x2x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "coeff": "duql_2222",
+      "comment": "# Cduq2x2x2x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        3
+      ],
+      "coeff": "duql_2223",
+      "comment": "# Cduq2x2x2x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        1
+      ],
+      "coeff": "duql_2231",
+      "comment": "# Cduq2x2x3x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        2
+      ],
+      "coeff": "duql_2232",
+      "comment": "# Cduq2x2x3x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        3
+      ],
+      "coeff": "duql_2233",
+      "comment": "# Cduq2x2x3x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        1
+      ],
+      "coeff": "duql_2311",
+      "comment": "# Cduq2x3x1x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        2
+      ],
+      "coeff": "duql_2312",
+      "comment": "# Cduq2x3x1x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        3
+      ],
+      "coeff": "duql_2313",
+      "comment": "# Cduq2x3x1x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        1
+      ],
+      "coeff": "duql_2321",
+      "comment": "# Cduq2x3x2x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        2
+      ],
+      "coeff": "duql_2322",
+      "comment": "# Cduq2x3x2x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        3
+      ],
+      "coeff": "duql_2323",
+      "comment": "# Cduq2x3x2x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        1
+      ],
+      "coeff": "duql_2331",
+      "comment": "# Cduq2x3x3x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        2
+      ],
+      "coeff": "duql_2332",
+      "comment": "# Cduq2x3x3x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        3
+      ],
+      "coeff": "duql_2333",
+      "comment": "# Cduq2x3x3x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        1
+      ],
+      "coeff": "duql_3111",
+      "comment": "# Cduq3x1x1x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        2
+      ],
+      "coeff": "duql_3112",
+      "comment": "# Cduq3x1x1x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        3
+      ],
+      "coeff": "duql_3113",
+      "comment": "# Cduq3x1x1x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        1
+      ],
+      "coeff": "duql_3121",
+      "comment": "# Cduq3x1x2x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        2
+      ],
+      "coeff": "duql_3122",
+      "comment": "# Cduq3x1x2x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        3
+      ],
+      "coeff": "duql_3123",
+      "comment": "# Cduq3x1x2x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        1
+      ],
+      "coeff": "duql_3131",
+      "comment": "# Cduq3x1x3x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        2
+      ],
+      "coeff": "duql_3132",
+      "comment": "# Cduq3x1x3x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        3
+      ],
+      "coeff": "duql_3133",
+      "comment": "# Cduq3x1x3x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        1
+      ],
+      "coeff": "duql_3211",
+      "comment": "# Cduq3x2x1x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        2
+      ],
+      "coeff": "duql_3212",
+      "comment": "# Cduq3x2x1x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        3
+      ],
+      "coeff": "duql_3213",
+      "comment": "# Cduq3x2x1x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        1
+      ],
+      "coeff": "duql_3221",
+      "comment": "# Cduq3x2x2x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        2
+      ],
+      "coeff": "duql_3222",
+      "comment": "# Cduq3x2x2x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        3
+      ],
+      "coeff": "duql_3223",
+      "comment": "# Cduq3x2x2x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "coeff": "duql_3231",
+      "comment": "# Cduq3x2x3x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        2
+      ],
+      "coeff": "duql_3232",
+      "comment": "# Cduq3x2x3x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        3
+      ],
+      "coeff": "duql_3233",
+      "comment": "# Cduq3x2x3x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        1
+      ],
+      "coeff": "duql_3311",
+      "comment": "# Cduq3x3x1x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        2
+      ],
+      "coeff": "duql_3312",
+      "comment": "# Cduq3x3x1x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        3
+      ],
+      "coeff": "duql_3313",
+      "comment": "# Cduq3x3x1x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        1
+      ],
+      "coeff": "duql_3321",
+      "comment": "# Cduq3x3x2x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        2
+      ],
+      "coeff": "duql_3322",
+      "comment": "# Cduq3x3x2x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        3
+      ],
+      "coeff": "duql_3323",
+      "comment": "# Cduq3x3x2x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        1
+      ],
+      "coeff": "duql_3331",
+      "comment": "# Cduq3x3x3x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        2
+      ],
+      "coeff": "duql_3332",
+      "comment": "# Cduq3x3x3x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        3
+      ],
+      "coeff": "duql_3333",
+      "comment": "# Cduq3x3x3x3 "
+    }
+  ],
+  "frblock26": [
+    {
+      "index": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "coeff": "duue_1111",
+      "comment": "# Cduu1x1x1x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        2
+      ],
+      "coeff": "duue_1112",
+      "comment": "# Cduu1x1x1x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        3
+      ],
+      "coeff": "duue_1113",
+      "comment": "# Cduu1x1x1x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        1
+      ],
+      "coeff": "duue_1121",
+      "comment": "# Cduu1x1x2x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "coeff": "duue_1122",
+      "comment": "# Cduu1x1x2x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "coeff": "duue_1123",
+      "comment": "# Cduu1x1x2x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        1
+      ],
+      "coeff": "duue_1131",
+      "comment": "# Cduu1x1x3x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        2
+      ],
+      "coeff": "duue_1132",
+      "comment": "# Cduu1x1x3x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        3
+      ],
+      "coeff": "duue_1133",
+      "comment": "# Cduu1x1x3x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        1
+      ],
+      "coeff": "duue_1211",
+      "comment": "# Cduu1x2x1x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        2
+      ],
+      "coeff": "duue_1212",
+      "comment": "# Cduu1x2x1x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        3
+      ],
+      "coeff": "duue_1213",
+      "comment": "# Cduu1x2x1x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        1
+      ],
+      "coeff": "duue_1221",
+      "comment": "# Cduu1x2x2x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        2
+      ],
+      "coeff": "duue_1222",
+      "comment": "# Cduu1x2x2x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        3
+      ],
+      "coeff": "duue_1223",
+      "comment": "# Cduu1x2x2x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        1
+      ],
+      "coeff": "duue_1231",
+      "comment": "# Cduu1x2x3x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        2
+      ],
+      "coeff": "duue_1232",
+      "comment": "# Cduu1x2x3x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        3
+      ],
+      "coeff": "duue_1233",
+      "comment": "# Cduu1x2x3x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        1
+      ],
+      "coeff": "duue_1311",
+      "comment": "# Cduu1x3x1x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        2
+      ],
+      "coeff": "duue_1312",
+      "comment": "# Cduu1x3x1x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        3
+      ],
+      "coeff": "duue_1313",
+      "comment": "# Cduu1x3x1x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        1
+      ],
+      "coeff": "duue_1321",
+      "comment": "# Cduu1x3x2x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        2
+      ],
+      "coeff": "duue_1322",
+      "comment": "# Cduu1x3x2x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        3
+      ],
+      "coeff": "duue_1323",
+      "comment": "# Cduu1x3x2x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        1
+      ],
+      "coeff": "duue_1331",
+      "comment": "# Cduu1x3x3x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        2
+      ],
+      "coeff": "duue_1332",
+      "comment": "# Cduu1x3x3x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        3
+      ],
+      "coeff": "duue_1333",
+      "comment": "# Cduu1x3x3x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "coeff": "duue_2111",
+      "comment": "# Cduu2x1x1x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        2
+      ],
+      "coeff": "duue_2112",
+      "comment": "# Cduu2x1x1x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        3
+      ],
+      "coeff": "duue_2113",
+      "comment": "# Cduu2x1x1x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "coeff": "duue_2121",
+      "comment": "# Cduu2x1x2x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        2
+      ],
+      "coeff": "duue_2122",
+      "comment": "# Cduu2x1x2x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "coeff": "duue_2123",
+      "comment": "# Cduu2x1x2x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        1
+      ],
+      "coeff": "duue_2131",
+      "comment": "# Cduu2x1x3x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        2
+      ],
+      "coeff": "duue_2132",
+      "comment": "# Cduu2x1x3x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        3
+      ],
+      "coeff": "duue_2133",
+      "comment": "# Cduu2x1x3x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        1
+      ],
+      "coeff": "duue_2211",
+      "comment": "# Cduu2x2x1x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        2
+      ],
+      "coeff": "duue_2212",
+      "comment": "# Cduu2x2x1x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        3
+      ],
+      "coeff": "duue_2213",
+      "comment": "# Cduu2x2x1x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        1
+      ],
+      "coeff": "duue_2221",
+      "comment": "# Cduu2x2x2x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "coeff": "duue_2222",
+      "comment": "# Cduu2x2x2x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        3
+      ],
+      "coeff": "duue_2223",
+      "comment": "# Cduu2x2x2x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        1
+      ],
+      "coeff": "duue_2231",
+      "comment": "# Cduu2x2x3x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        2
+      ],
+      "coeff": "duue_2232",
+      "comment": "# Cduu2x2x3x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        3
+      ],
+      "coeff": "duue_2233",
+      "comment": "# Cduu2x2x3x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        1
+      ],
+      "coeff": "duue_2311",
+      "comment": "# Cduu2x3x1x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        2
+      ],
+      "coeff": "duue_2312",
+      "comment": "# Cduu2x3x1x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        3
+      ],
+      "coeff": "duue_2313",
+      "comment": "# Cduu2x3x1x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        1
+      ],
+      "coeff": "duue_2321",
+      "comment": "# Cduu2x3x2x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        2
+      ],
+      "coeff": "duue_2322",
+      "comment": "# Cduu2x3x2x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        3
+      ],
+      "coeff": "duue_2323",
+      "comment": "# Cduu2x3x2x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        1
+      ],
+      "coeff": "duue_2331",
+      "comment": "# Cduu2x3x3x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        2
+      ],
+      "coeff": "duue_2332",
+      "comment": "# Cduu2x3x3x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        3
+      ],
+      "coeff": "duue_2333",
+      "comment": "# Cduu2x3x3x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        1
+      ],
+      "coeff": "duue_3111",
+      "comment": "# Cduu3x1x1x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        2
+      ],
+      "coeff": "duue_3112",
+      "comment": "# Cduu3x1x1x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        3
+      ],
+      "coeff": "duue_3113",
+      "comment": "# Cduu3x1x1x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        1
+      ],
+      "coeff": "duue_3121",
+      "comment": "# Cduu3x1x2x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        2
+      ],
+      "coeff": "duue_3122",
+      "comment": "# Cduu3x1x2x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        3
+      ],
+      "coeff": "duue_3123",
+      "comment": "# Cduu3x1x2x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        1
+      ],
+      "coeff": "duue_3131",
+      "comment": "# Cduu3x1x3x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        2
+      ],
+      "coeff": "duue_3132",
+      "comment": "# Cduu3x1x3x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        3
+      ],
+      "coeff": "duue_3133",
+      "comment": "# Cduu3x1x3x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        1
+      ],
+      "coeff": "duue_3211",
+      "comment": "# Cduu3x2x1x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        2
+      ],
+      "coeff": "duue_3212",
+      "comment": "# Cduu3x2x1x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        3
+      ],
+      "coeff": "duue_3213",
+      "comment": "# Cduu3x2x1x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        1
+      ],
+      "coeff": "duue_3221",
+      "comment": "# Cduu3x2x2x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        2
+      ],
+      "coeff": "duue_3222",
+      "comment": "# Cduu3x2x2x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        3
+      ],
+      "coeff": "duue_3223",
+      "comment": "# Cduu3x2x2x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "coeff": "duue_3231",
+      "comment": "# Cduu3x2x3x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        2
+      ],
+      "coeff": "duue_3232",
+      "comment": "# Cduu3x2x3x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        3
+      ],
+      "coeff": "duue_3233",
+      "comment": "# Cduu3x2x3x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        1
+      ],
+      "coeff": "duue_3311",
+      "comment": "# Cduu3x3x1x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        2
+      ],
+      "coeff": "duue_3312",
+      "comment": "# Cduu3x3x1x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        3
+      ],
+      "coeff": "duue_3313",
+      "comment": "# Cduu3x3x1x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        1
+      ],
+      "coeff": "duue_3321",
+      "comment": "# Cduu3x3x2x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        2
+      ],
+      "coeff": "duue_3322",
+      "comment": "# Cduu3x3x2x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        3
+      ],
+      "coeff": "duue_3323",
+      "comment": "# Cduu3x3x2x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        1
+      ],
+      "coeff": "duue_3331",
+      "comment": "# Cduu3x3x3x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        2
+      ],
+      "coeff": "duue_3332",
+      "comment": "# Cduu3x3x3x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        3
+      ],
+      "coeff": "duue_3333",
+      "comment": "# Cduu3x3x3x3 "
+    }
+  ],
+  "frblock27": [
+    {
+      "index": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "coeff": "ed_1111",
+      "comment": "# Ced1x1x1x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        2
+      ],
+      "coeff": "ed_1112",
+      "comment": "# Ced1x1x1x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        3
+      ],
+      "coeff": "ed_1113",
+      "comment": "# Ced1x1x1x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        1
+      ],
+      "coeff": "ed_1121",
+      "comment": "# Ced1x1x2x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "coeff": "ed_1122",
+      "comment": "# Ced1x1x2x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "coeff": "ed_1123",
+      "comment": "# Ced1x1x2x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        1
+      ],
+      "coeff": "ed_1131",
+      "comment": "# Ced1x1x3x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        2
+      ],
+      "coeff": "ed_1132",
+      "comment": "# Ced1x1x3x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        3
+      ],
+      "coeff": "ed_1133",
+      "comment": "# Ced1x1x3x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        1
+      ],
+      "coeff": "ed_1211",
+      "comment": "# Ced1x2x1x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        2
+      ],
+      "coeff": "ed_1212",
+      "comment": "# Ced1x2x1x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        3
+      ],
+      "coeff": "ed_1213",
+      "comment": "# Ced1x2x1x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        1
+      ],
+      "coeff": "ed_1221",
+      "comment": "# Ced1x2x2x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        2
+      ],
+      "coeff": "ed_1222",
+      "comment": "# Ced1x2x2x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        3
+      ],
+      "coeff": "ed_1223",
+      "comment": "# Ced1x2x2x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        1
+      ],
+      "coeff": "ed_1231",
+      "comment": "# Ced1x2x3x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        2
+      ],
+      "coeff": "ed_1232",
+      "comment": "# Ced1x2x3x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        3
+      ],
+      "coeff": "ed_1233",
+      "comment": "# Ced1x2x3x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        1
+      ],
+      "coeff": "ed_1311",
+      "comment": "# Ced1x3x1x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        2
+      ],
+      "coeff": "ed_1312",
+      "comment": "# Ced1x3x1x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        3
+      ],
+      "coeff": "ed_1313",
+      "comment": "# Ced1x3x1x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        1
+      ],
+      "coeff": "ed_1321",
+      "comment": "# Ced1x3x2x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        2
+      ],
+      "coeff": "ed_1322",
+      "comment": "# Ced1x3x2x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        3
+      ],
+      "coeff": "ed_1323",
+      "comment": "# Ced1x3x2x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        1
+      ],
+      "coeff": "ed_1331",
+      "comment": "# Ced1x3x3x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        2
+      ],
+      "coeff": "ed_1332",
+      "comment": "# Ced1x3x3x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        3
+      ],
+      "coeff": "ed_1333",
+      "comment": "# Ced1x3x3x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "coeff": "ed_2111",
+      "comment": "# Ced2x1x1x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        2
+      ],
+      "coeff": "ed_2112",
+      "comment": "# Ced2x1x1x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        3
+      ],
+      "coeff": "ed_2113",
+      "comment": "# Ced2x1x1x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "coeff": "ed_2121",
+      "comment": "# Ced2x1x2x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        2
+      ],
+      "coeff": "ed_2122",
+      "comment": "# Ced2x1x2x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "coeff": "ed_2123",
+      "comment": "# Ced2x1x2x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        1
+      ],
+      "coeff": "ed_2131",
+      "comment": "# Ced2x1x3x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        2
+      ],
+      "coeff": "ed_2132",
+      "comment": "# Ced2x1x3x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        3
+      ],
+      "coeff": "ed_2133",
+      "comment": "# Ced2x1x3x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        1
+      ],
+      "coeff": "ed_2211",
+      "comment": "# Ced2x2x1x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        2
+      ],
+      "coeff": "ed_2212",
+      "comment": "# Ced2x2x1x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        3
+      ],
+      "coeff": "ed_2213",
+      "comment": "# Ced2x2x1x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        1
+      ],
+      "coeff": "ed_2221",
+      "comment": "# Ced2x2x2x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "coeff": "ed_2222",
+      "comment": "# Ced2x2x2x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        3
+      ],
+      "coeff": "ed_2223",
+      "comment": "# Ced2x2x2x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        1
+      ],
+      "coeff": "ed_2231",
+      "comment": "# Ced2x2x3x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        2
+      ],
+      "coeff": "ed_2232",
+      "comment": "# Ced2x2x3x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        3
+      ],
+      "coeff": "ed_2233",
+      "comment": "# Ced2x2x3x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        1
+      ],
+      "coeff": "ed_2311",
+      "comment": "# Ced2x3x1x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        2
+      ],
+      "coeff": "ed_2312",
+      "comment": "# Ced2x3x1x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        3
+      ],
+      "coeff": "ed_2313",
+      "comment": "# Ced2x3x1x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        1
+      ],
+      "coeff": "ed_2321",
+      "comment": "# Ced2x3x2x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        2
+      ],
+      "coeff": "ed_2322",
+      "comment": "# Ced2x3x2x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        3
+      ],
+      "coeff": "ed_2323",
+      "comment": "# Ced2x3x2x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        1
+      ],
+      "coeff": "ed_2331",
+      "comment": "# Ced2x3x3x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        2
+      ],
+      "coeff": "ed_2332",
+      "comment": "# Ced2x3x3x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        3
+      ],
+      "coeff": "ed_2333",
+      "comment": "# Ced2x3x3x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        1
+      ],
+      "coeff": "ed_3111",
+      "comment": "# Ced3x1x1x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        2
+      ],
+      "coeff": "ed_3112",
+      "comment": "# Ced3x1x1x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        3
+      ],
+      "coeff": "ed_3113",
+      "comment": "# Ced3x1x1x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        1
+      ],
+      "coeff": "ed_3121",
+      "comment": "# Ced3x1x2x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        2
+      ],
+      "coeff": "ed_3122",
+      "comment": "# Ced3x1x2x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        3
+      ],
+      "coeff": "ed_3123",
+      "comment": "# Ced3x1x2x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        1
+      ],
+      "coeff": "ed_3131",
+      "comment": "# Ced3x1x3x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        2
+      ],
+      "coeff": "ed_3132",
+      "comment": "# Ced3x1x3x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        3
+      ],
+      "coeff": "ed_3133",
+      "comment": "# Ced3x1x3x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        1
+      ],
+      "coeff": "ed_3211",
+      "comment": "# Ced3x2x1x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        2
+      ],
+      "coeff": "ed_3212",
+      "comment": "# Ced3x2x1x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        3
+      ],
+      "coeff": "ed_3213",
+      "comment": "# Ced3x2x1x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        1
+      ],
+      "coeff": "ed_3221",
+      "comment": "# Ced3x2x2x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        2
+      ],
+      "coeff": "ed_3222",
+      "comment": "# Ced3x2x2x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        3
+      ],
+      "coeff": "ed_3223",
+      "comment": "# Ced3x2x2x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "coeff": "ed_3231",
+      "comment": "# Ced3x2x3x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        2
+      ],
+      "coeff": "ed_3232",
+      "comment": "# Ced3x2x3x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        3
+      ],
+      "coeff": "ed_3233",
+      "comment": "# Ced3x2x3x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        1
+      ],
+      "coeff": "ed_3311",
+      "comment": "# Ced3x3x1x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        2
+      ],
+      "coeff": "ed_3312",
+      "comment": "# Ced3x3x1x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        3
+      ],
+      "coeff": "ed_3313",
+      "comment": "# Ced3x3x1x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        1
+      ],
+      "coeff": "ed_3321",
+      "comment": "# Ced3x3x2x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        2
+      ],
+      "coeff": "ed_3322",
+      "comment": "# Ced3x3x2x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        3
+      ],
+      "coeff": "ed_3323",
+      "comment": "# Ced3x3x2x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        1
+      ],
+      "coeff": "ed_3331",
+      "comment": "# Ced3x3x3x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        2
+      ],
+      "coeff": "ed_3332",
+      "comment": "# Ced3x3x3x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        3
+      ],
+      "coeff": "ed_3333",
+      "comment": "# Ced3x3x3x3 "
+    }
+  ],
+  "frblock28": [
+    {
+      "index": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "coeff": "ee_1111",
+      "comment": "# Cee1x1x1x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        2
+      ],
+      "coeff": "ee_1112",
+      "comment": "# Cee1x1x1x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        3
+      ],
+      "coeff": "ee_1113",
+      "comment": "# Cee1x1x1x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        1
+      ],
+      "coeff": "ee_1121",
+      "comment": "# Cee1x1x2x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "coeff": "ee_1122",
+      "comment": "# Cee1x1x2x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "coeff": "ee_1123",
+      "comment": "# Cee1x1x2x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        1
+      ],
+      "coeff": "ee_1131",
+      "comment": "# Cee1x1x3x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        2
+      ],
+      "coeff": "ee_1132",
+      "comment": "# Cee1x1x3x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        3
+      ],
+      "coeff": "ee_1133",
+      "comment": "# Cee1x1x3x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        1
+      ],
+      "coeff": "ee_1211",
+      "comment": "# Cee1x2x1x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        2
+      ],
+      "coeff": "ee_1212",
+      "comment": "# Cee1x2x1x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        3
+      ],
+      "coeff": "ee_1213",
+      "comment": "# Cee1x2x1x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        1
+      ],
+      "coeff": "ee_1221",
+      "comment": "# Cee1x2x2x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        2
+      ],
+      "coeff": "ee_1222",
+      "comment": "# Cee1x2x2x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        3
+      ],
+      "coeff": "ee_1223",
+      "comment": "# Cee1x2x2x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        1
+      ],
+      "coeff": "ee_1231",
+      "comment": "# Cee1x2x3x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        2
+      ],
+      "coeff": "ee_1232",
+      "comment": "# Cee1x2x3x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        3
+      ],
+      "coeff": "ee_1233",
+      "comment": "# Cee1x2x3x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        1
+      ],
+      "coeff": "ee_1311",
+      "comment": "# Cee1x3x1x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        2
+      ],
+      "coeff": "ee_1312",
+      "comment": "# Cee1x3x1x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        3
+      ],
+      "coeff": "ee_1313",
+      "comment": "# Cee1x3x1x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        1
+      ],
+      "coeff": "ee_1321",
+      "comment": "# Cee1x3x2x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        2
+      ],
+      "coeff": "ee_1322",
+      "comment": "# Cee1x3x2x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        3
+      ],
+      "coeff": "ee_1323",
+      "comment": "# Cee1x3x2x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        1
+      ],
+      "coeff": "ee_1331",
+      "comment": "# Cee1x3x3x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        2
+      ],
+      "coeff": "ee_1332",
+      "comment": "# Cee1x3x3x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        3
+      ],
+      "coeff": "ee_1333",
+      "comment": "# Cee1x3x3x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "coeff": "ee_2111",
+      "comment": "# Cee2x1x1x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        2
+      ],
+      "coeff": "ee_2112",
+      "comment": "# Cee2x1x1x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        3
+      ],
+      "coeff": "ee_2113",
+      "comment": "# Cee2x1x1x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "coeff": "ee_2121",
+      "comment": "# Cee2x1x2x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        2
+      ],
+      "coeff": "ee_2122",
+      "comment": "# Cee2x1x2x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "coeff": "ee_2123",
+      "comment": "# Cee2x1x2x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        1
+      ],
+      "coeff": "ee_2131",
+      "comment": "# Cee2x1x3x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        2
+      ],
+      "coeff": "ee_2132",
+      "comment": "# Cee2x1x3x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        3
+      ],
+      "coeff": "ee_2133",
+      "comment": "# Cee2x1x3x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        1
+      ],
+      "coeff": "ee_2211",
+      "comment": "# Cee2x2x1x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        2
+      ],
+      "coeff": "ee_2212",
+      "comment": "# Cee2x2x1x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        3
+      ],
+      "coeff": "ee_2213",
+      "comment": "# Cee2x2x1x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        1
+      ],
+      "coeff": "ee_2221",
+      "comment": "# Cee2x2x2x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "coeff": "ee_2222",
+      "comment": "# Cee2x2x2x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        3
+      ],
+      "coeff": "ee_2223",
+      "comment": "# Cee2x2x2x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        1
+      ],
+      "coeff": "ee_2231",
+      "comment": "# Cee2x2x3x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        2
+      ],
+      "coeff": "ee_2232",
+      "comment": "# Cee2x2x3x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        3
+      ],
+      "coeff": "ee_2233",
+      "comment": "# Cee2x2x3x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        1
+      ],
+      "coeff": "ee_2311",
+      "comment": "# Cee2x3x1x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        2
+      ],
+      "coeff": "ee_2312",
+      "comment": "# Cee2x3x1x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        3
+      ],
+      "coeff": "ee_2313",
+      "comment": "# Cee2x3x1x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        1
+      ],
+      "coeff": "ee_2321",
+      "comment": "# Cee2x3x2x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        2
+      ],
+      "coeff": "ee_2322",
+      "comment": "# Cee2x3x2x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        3
+      ],
+      "coeff": "ee_2323",
+      "comment": "# Cee2x3x2x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        1
+      ],
+      "coeff": "ee_2331",
+      "comment": "# Cee2x3x3x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        2
+      ],
+      "coeff": "ee_2332",
+      "comment": "# Cee2x3x3x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        3
+      ],
+      "coeff": "ee_2333",
+      "comment": "# Cee2x3x3x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        1
+      ],
+      "coeff": "ee_3111",
+      "comment": "# Cee3x1x1x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        2
+      ],
+      "coeff": "ee_3112",
+      "comment": "# Cee3x1x1x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        3
+      ],
+      "coeff": "ee_3113",
+      "comment": "# Cee3x1x1x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        1
+      ],
+      "coeff": "ee_3121",
+      "comment": "# Cee3x1x2x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        2
+      ],
+      "coeff": "ee_3122",
+      "comment": "# Cee3x1x2x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        3
+      ],
+      "coeff": "ee_3123",
+      "comment": "# Cee3x1x2x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        1
+      ],
+      "coeff": "ee_3131",
+      "comment": "# Cee3x1x3x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        2
+      ],
+      "coeff": "ee_3132",
+      "comment": "# Cee3x1x3x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        3
+      ],
+      "coeff": "ee_3133",
+      "comment": "# Cee3x1x3x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        1
+      ],
+      "coeff": "ee_3211",
+      "comment": "# Cee3x2x1x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        2
+      ],
+      "coeff": "ee_3212",
+      "comment": "# Cee3x2x1x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        3
+      ],
+      "coeff": "ee_3213",
+      "comment": "# Cee3x2x1x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        1
+      ],
+      "coeff": "ee_3221",
+      "comment": "# Cee3x2x2x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        2
+      ],
+      "coeff": "ee_3222",
+      "comment": "# Cee3x2x2x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        3
+      ],
+      "coeff": "ee_3223",
+      "comment": "# Cee3x2x2x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "coeff": "ee_3231",
+      "comment": "# Cee3x2x3x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        2
+      ],
+      "coeff": "ee_3232",
+      "comment": "# Cee3x2x3x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        3
+      ],
+      "coeff": "ee_3233",
+      "comment": "# Cee3x2x3x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        1
+      ],
+      "coeff": "ee_3311",
+      "comment": "# Cee3x3x1x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        2
+      ],
+      "coeff": "ee_3312",
+      "comment": "# Cee3x3x1x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        3
+      ],
+      "coeff": "ee_3313",
+      "comment": "# Cee3x3x1x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        1
+      ],
+      "coeff": "ee_3321",
+      "comment": "# Cee3x3x2x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        2
+      ],
+      "coeff": "ee_3322",
+      "comment": "# Cee3x3x2x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        3
+      ],
+      "coeff": "ee_3323",
+      "comment": "# Cee3x3x2x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        1
+      ],
+      "coeff": "ee_3331",
+      "comment": "# Cee3x3x3x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        2
+      ],
+      "coeff": "ee_3332",
+      "comment": "# Cee3x3x3x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        3
+      ],
+      "coeff": "ee_3333",
+      "comment": "# Cee3x3x3x3 "
+    }
+  ],
+  "frblock29": [
+    {
+      "index": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "coeff": "eu_1111",
+      "comment": "# Ceu1x1x1x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        2
+      ],
+      "coeff": "eu_1112",
+      "comment": "# Ceu1x1x1x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        3
+      ],
+      "coeff": "eu_1113",
+      "comment": "# Ceu1x1x1x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        1
+      ],
+      "coeff": "eu_1121",
+      "comment": "# Ceu1x1x2x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "coeff": "eu_1122",
+      "comment": "# Ceu1x1x2x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "coeff": "eu_1123",
+      "comment": "# Ceu1x1x2x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        1
+      ],
+      "coeff": "eu_1131",
+      "comment": "# Ceu1x1x3x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        2
+      ],
+      "coeff": "eu_1132",
+      "comment": "# Ceu1x1x3x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        3
+      ],
+      "coeff": "eu_1133",
+      "comment": "# Ceu1x1x3x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        1
+      ],
+      "coeff": "eu_1211",
+      "comment": "# Ceu1x2x1x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        2
+      ],
+      "coeff": "eu_1212",
+      "comment": "# Ceu1x2x1x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        3
+      ],
+      "coeff": "eu_1213",
+      "comment": "# Ceu1x2x1x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        1
+      ],
+      "coeff": "eu_1221",
+      "comment": "# Ceu1x2x2x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        2
+      ],
+      "coeff": "eu_1222",
+      "comment": "# Ceu1x2x2x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        3
+      ],
+      "coeff": "eu_1223",
+      "comment": "# Ceu1x2x2x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        1
+      ],
+      "coeff": "eu_1231",
+      "comment": "# Ceu1x2x3x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        2
+      ],
+      "coeff": "eu_1232",
+      "comment": "# Ceu1x2x3x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        3
+      ],
+      "coeff": "eu_1233",
+      "comment": "# Ceu1x2x3x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        1
+      ],
+      "coeff": "eu_1311",
+      "comment": "# Ceu1x3x1x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        2
+      ],
+      "coeff": "eu_1312",
+      "comment": "# Ceu1x3x1x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        3
+      ],
+      "coeff": "eu_1313",
+      "comment": "# Ceu1x3x1x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        1
+      ],
+      "coeff": "eu_1321",
+      "comment": "# Ceu1x3x2x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        2
+      ],
+      "coeff": "eu_1322",
+      "comment": "# Ceu1x3x2x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        3
+      ],
+      "coeff": "eu_1323",
+      "comment": "# Ceu1x3x2x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        1
+      ],
+      "coeff": "eu_1331",
+      "comment": "# Ceu1x3x3x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        2
+      ],
+      "coeff": "eu_1332",
+      "comment": "# Ceu1x3x3x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        3
+      ],
+      "coeff": "eu_1333",
+      "comment": "# Ceu1x3x3x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "coeff": "eu_2111",
+      "comment": "# Ceu2x1x1x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        2
+      ],
+      "coeff": "eu_2112",
+      "comment": "# Ceu2x1x1x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        3
+      ],
+      "coeff": "eu_2113",
+      "comment": "# Ceu2x1x1x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "coeff": "eu_2121",
+      "comment": "# Ceu2x1x2x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        2
+      ],
+      "coeff": "eu_2122",
+      "comment": "# Ceu2x1x2x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "coeff": "eu_2123",
+      "comment": "# Ceu2x1x2x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        1
+      ],
+      "coeff": "eu_2131",
+      "comment": "# Ceu2x1x3x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        2
+      ],
+      "coeff": "eu_2132",
+      "comment": "# Ceu2x1x3x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        3
+      ],
+      "coeff": "eu_2133",
+      "comment": "# Ceu2x1x3x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        1
+      ],
+      "coeff": "eu_2211",
+      "comment": "# Ceu2x2x1x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        2
+      ],
+      "coeff": "eu_2212",
+      "comment": "# Ceu2x2x1x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        3
+      ],
+      "coeff": "eu_2213",
+      "comment": "# Ceu2x2x1x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        1
+      ],
+      "coeff": "eu_2221",
+      "comment": "# Ceu2x2x2x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "coeff": "eu_2222",
+      "comment": "# Ceu2x2x2x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        3
+      ],
+      "coeff": "eu_2223",
+      "comment": "# Ceu2x2x2x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        1
+      ],
+      "coeff": "eu_2231",
+      "comment": "# Ceu2x2x3x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        2
+      ],
+      "coeff": "eu_2232",
+      "comment": "# Ceu2x2x3x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        3
+      ],
+      "coeff": "eu_2233",
+      "comment": "# Ceu2x2x3x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        1
+      ],
+      "coeff": "eu_2311",
+      "comment": "# Ceu2x3x1x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        2
+      ],
+      "coeff": "eu_2312",
+      "comment": "# Ceu2x3x1x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        3
+      ],
+      "coeff": "eu_2313",
+      "comment": "# Ceu2x3x1x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        1
+      ],
+      "coeff": "eu_2321",
+      "comment": "# Ceu2x3x2x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        2
+      ],
+      "coeff": "eu_2322",
+      "comment": "# Ceu2x3x2x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        3
+      ],
+      "coeff": "eu_2323",
+      "comment": "# Ceu2x3x2x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        1
+      ],
+      "coeff": "eu_2331",
+      "comment": "# Ceu2x3x3x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        2
+      ],
+      "coeff": "eu_2332",
+      "comment": "# Ceu2x3x3x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        3
+      ],
+      "coeff": "eu_2333",
+      "comment": "# Ceu2x3x3x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        1
+      ],
+      "coeff": "eu_3111",
+      "comment": "# Ceu3x1x1x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        2
+      ],
+      "coeff": "eu_3112",
+      "comment": "# Ceu3x1x1x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        3
+      ],
+      "coeff": "eu_3113",
+      "comment": "# Ceu3x1x1x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        1
+      ],
+      "coeff": "eu_3121",
+      "comment": "# Ceu3x1x2x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        2
+      ],
+      "coeff": "eu_3122",
+      "comment": "# Ceu3x1x2x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        3
+      ],
+      "coeff": "eu_3123",
+      "comment": "# Ceu3x1x2x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        1
+      ],
+      "coeff": "eu_3131",
+      "comment": "# Ceu3x1x3x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        2
+      ],
+      "coeff": "eu_3132",
+      "comment": "# Ceu3x1x3x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        3
+      ],
+      "coeff": "eu_3133",
+      "comment": "# Ceu3x1x3x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        1
+      ],
+      "coeff": "eu_3211",
+      "comment": "# Ceu3x2x1x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        2
+      ],
+      "coeff": "eu_3212",
+      "comment": "# Ceu3x2x1x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        3
+      ],
+      "coeff": "eu_3213",
+      "comment": "# Ceu3x2x1x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        1
+      ],
+      "coeff": "eu_3221",
+      "comment": "# Ceu3x2x2x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        2
+      ],
+      "coeff": "eu_3222",
+      "comment": "# Ceu3x2x2x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        3
+      ],
+      "coeff": "eu_3223",
+      "comment": "# Ceu3x2x2x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "coeff": "eu_3231",
+      "comment": "# Ceu3x2x3x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        2
+      ],
+      "coeff": "eu_3232",
+      "comment": "# Ceu3x2x3x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        3
+      ],
+      "coeff": "eu_3233",
+      "comment": "# Ceu3x2x3x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        1
+      ],
+      "coeff": "eu_3311",
+      "comment": "# Ceu3x3x1x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        2
+      ],
+      "coeff": "eu_3312",
+      "comment": "# Ceu3x3x1x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        3
+      ],
+      "coeff": "eu_3313",
+      "comment": "# Ceu3x3x1x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        1
+      ],
+      "coeff": "eu_3321",
+      "comment": "# Ceu3x3x2x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        2
+      ],
+      "coeff": "eu_3322",
+      "comment": "# Ceu3x3x2x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        3
+      ],
+      "coeff": "eu_3323",
+      "comment": "# Ceu3x3x2x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        1
+      ],
+      "coeff": "eu_3331",
+      "comment": "# Ceu3x3x3x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        2
+      ],
+      "coeff": "eu_3332",
+      "comment": "# Ceu3x3x3x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        3
+      ],
+      "coeff": "eu_3333",
+      "comment": "# Ceu3x3x3x3 "
+    }
+  ],
+  "frblock30": [
+    {
+      "index": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "coeff": "ld_1111",
+      "comment": "# Cld1x1x1x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        2
+      ],
+      "coeff": "ld_1112",
+      "comment": "# Cld1x1x1x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        3
+      ],
+      "coeff": "ld_1113",
+      "comment": "# Cld1x1x1x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        1
+      ],
+      "coeff": "ld_1121",
+      "comment": "# Cld1x1x2x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "coeff": "ld_1122",
+      "comment": "# Cld1x1x2x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "coeff": "ld_1123",
+      "comment": "# Cld1x1x2x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        1
+      ],
+      "coeff": "ld_1131",
+      "comment": "# Cld1x1x3x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        2
+      ],
+      "coeff": "ld_1132",
+      "comment": "# Cld1x1x3x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        3
+      ],
+      "coeff": "ld_1133",
+      "comment": "# Cld1x1x3x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        1
+      ],
+      "coeff": "ld_1211",
+      "comment": "# Cld1x2x1x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        2
+      ],
+      "coeff": "ld_1212",
+      "comment": "# Cld1x2x1x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        3
+      ],
+      "coeff": "ld_1213",
+      "comment": "# Cld1x2x1x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        1
+      ],
+      "coeff": "ld_1221",
+      "comment": "# Cld1x2x2x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        2
+      ],
+      "coeff": "ld_1222",
+      "comment": "# Cld1x2x2x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        3
+      ],
+      "coeff": "ld_1223",
+      "comment": "# Cld1x2x2x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        1
+      ],
+      "coeff": "ld_1231",
+      "comment": "# Cld1x2x3x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        2
+      ],
+      "coeff": "ld_1232",
+      "comment": "# Cld1x2x3x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        3
+      ],
+      "coeff": "ld_1233",
+      "comment": "# Cld1x2x3x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        1
+      ],
+      "coeff": "ld_1311",
+      "comment": "# Cld1x3x1x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        2
+      ],
+      "coeff": "ld_1312",
+      "comment": "# Cld1x3x1x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        3
+      ],
+      "coeff": "ld_1313",
+      "comment": "# Cld1x3x1x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        1
+      ],
+      "coeff": "ld_1321",
+      "comment": "# Cld1x3x2x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        2
+      ],
+      "coeff": "ld_1322",
+      "comment": "# Cld1x3x2x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        3
+      ],
+      "coeff": "ld_1323",
+      "comment": "# Cld1x3x2x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        1
+      ],
+      "coeff": "ld_1331",
+      "comment": "# Cld1x3x3x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        2
+      ],
+      "coeff": "ld_1332",
+      "comment": "# Cld1x3x3x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        3
+      ],
+      "coeff": "ld_1333",
+      "comment": "# Cld1x3x3x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "coeff": "ld_2111",
+      "comment": "# Cld2x1x1x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        2
+      ],
+      "coeff": "ld_2112",
+      "comment": "# Cld2x1x1x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        3
+      ],
+      "coeff": "ld_2113",
+      "comment": "# Cld2x1x1x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "coeff": "ld_2121",
+      "comment": "# Cld2x1x2x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        2
+      ],
+      "coeff": "ld_2122",
+      "comment": "# Cld2x1x2x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "coeff": "ld_2123",
+      "comment": "# Cld2x1x2x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        1
+      ],
+      "coeff": "ld_2131",
+      "comment": "# Cld2x1x3x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        2
+      ],
+      "coeff": "ld_2132",
+      "comment": "# Cld2x1x3x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        3
+      ],
+      "coeff": "ld_2133",
+      "comment": "# Cld2x1x3x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        1
+      ],
+      "coeff": "ld_2211",
+      "comment": "# Cld2x2x1x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        2
+      ],
+      "coeff": "ld_2212",
+      "comment": "# Cld2x2x1x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        3
+      ],
+      "coeff": "ld_2213",
+      "comment": "# Cld2x2x1x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        1
+      ],
+      "coeff": "ld_2221",
+      "comment": "# Cld2x2x2x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "coeff": "ld_2222",
+      "comment": "# Cld2x2x2x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        3
+      ],
+      "coeff": "ld_2223",
+      "comment": "# Cld2x2x2x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        1
+      ],
+      "coeff": "ld_2231",
+      "comment": "# Cld2x2x3x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        2
+      ],
+      "coeff": "ld_2232",
+      "comment": "# Cld2x2x3x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        3
+      ],
+      "coeff": "ld_2233",
+      "comment": "# Cld2x2x3x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        1
+      ],
+      "coeff": "ld_2311",
+      "comment": "# Cld2x3x1x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        2
+      ],
+      "coeff": "ld_2312",
+      "comment": "# Cld2x3x1x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        3
+      ],
+      "coeff": "ld_2313",
+      "comment": "# Cld2x3x1x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        1
+      ],
+      "coeff": "ld_2321",
+      "comment": "# Cld2x3x2x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        2
+      ],
+      "coeff": "ld_2322",
+      "comment": "# Cld2x3x2x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        3
+      ],
+      "coeff": "ld_2323",
+      "comment": "# Cld2x3x2x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        1
+      ],
+      "coeff": "ld_2331",
+      "comment": "# Cld2x3x3x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        2
+      ],
+      "coeff": "ld_2332",
+      "comment": "# Cld2x3x3x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        3
+      ],
+      "coeff": "ld_2333",
+      "comment": "# Cld2x3x3x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        1
+      ],
+      "coeff": "ld_3111",
+      "comment": "# Cld3x1x1x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        2
+      ],
+      "coeff": "ld_3112",
+      "comment": "# Cld3x1x1x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        3
+      ],
+      "coeff": "ld_3113",
+      "comment": "# Cld3x1x1x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        1
+      ],
+      "coeff": "ld_3121",
+      "comment": "# Cld3x1x2x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        2
+      ],
+      "coeff": "ld_3122",
+      "comment": "# Cld3x1x2x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        3
+      ],
+      "coeff": "ld_3123",
+      "comment": "# Cld3x1x2x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        1
+      ],
+      "coeff": "ld_3131",
+      "comment": "# Cld3x1x3x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        2
+      ],
+      "coeff": "ld_3132",
+      "comment": "# Cld3x1x3x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        3
+      ],
+      "coeff": "ld_3133",
+      "comment": "# Cld3x1x3x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        1
+      ],
+      "coeff": "ld_3211",
+      "comment": "# Cld3x2x1x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        2
+      ],
+      "coeff": "ld_3212",
+      "comment": "# Cld3x2x1x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        3
+      ],
+      "coeff": "ld_3213",
+      "comment": "# Cld3x2x1x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        1
+      ],
+      "coeff": "ld_3221",
+      "comment": "# Cld3x2x2x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        2
+      ],
+      "coeff": "ld_3222",
+      "comment": "# Cld3x2x2x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        3
+      ],
+      "coeff": "ld_3223",
+      "comment": "# Cld3x2x2x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "coeff": "ld_3231",
+      "comment": "# Cld3x2x3x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        2
+      ],
+      "coeff": "ld_3232",
+      "comment": "# Cld3x2x3x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        3
+      ],
+      "coeff": "ld_3233",
+      "comment": "# Cld3x2x3x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        1
+      ],
+      "coeff": "ld_3311",
+      "comment": "# Cld3x3x1x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        2
+      ],
+      "coeff": "ld_3312",
+      "comment": "# Cld3x3x1x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        3
+      ],
+      "coeff": "ld_3313",
+      "comment": "# Cld3x3x1x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        1
+      ],
+      "coeff": "ld_3321",
+      "comment": "# Cld3x3x2x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        2
+      ],
+      "coeff": "ld_3322",
+      "comment": "# Cld3x3x2x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        3
+      ],
+      "coeff": "ld_3323",
+      "comment": "# Cld3x3x2x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        1
+      ],
+      "coeff": "ld_3331",
+      "comment": "# Cld3x3x3x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        2
+      ],
+      "coeff": "ld_3332",
+      "comment": "# Cld3x3x3x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        3
+      ],
+      "coeff": "ld_3333",
+      "comment": "# Cld3x3x3x3 "
+    }
+  ],
+  "frblock31": [
+    {
+      "index": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "coeff": "le_1111",
+      "comment": "# Cle1x1x1x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        2
+      ],
+      "coeff": "le_1112",
+      "comment": "# Cle1x1x1x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        3
+      ],
+      "coeff": "le_1113",
+      "comment": "# Cle1x1x1x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        1
+      ],
+      "coeff": "le_1121",
+      "comment": "# Cle1x1x2x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "coeff": "le_1122",
+      "comment": "# Cle1x1x2x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "coeff": "le_1123",
+      "comment": "# Cle1x1x2x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        1
+      ],
+      "coeff": "le_1131",
+      "comment": "# Cle1x1x3x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        2
+      ],
+      "coeff": "le_1132",
+      "comment": "# Cle1x1x3x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        3
+      ],
+      "coeff": "le_1133",
+      "comment": "# Cle1x1x3x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        1
+      ],
+      "coeff": "le_1211",
+      "comment": "# Cle1x2x1x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        2
+      ],
+      "coeff": "le_1212",
+      "comment": "# Cle1x2x1x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        3
+      ],
+      "coeff": "le_1213",
+      "comment": "# Cle1x2x1x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        1
+      ],
+      "coeff": "le_1221",
+      "comment": "# Cle1x2x2x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        2
+      ],
+      "coeff": "le_1222",
+      "comment": "# Cle1x2x2x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        3
+      ],
+      "coeff": "le_1223",
+      "comment": "# Cle1x2x2x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        1
+      ],
+      "coeff": "le_1231",
+      "comment": "# Cle1x2x3x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        2
+      ],
+      "coeff": "le_1232",
+      "comment": "# Cle1x2x3x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        3
+      ],
+      "coeff": "le_1233",
+      "comment": "# Cle1x2x3x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        1
+      ],
+      "coeff": "le_1311",
+      "comment": "# Cle1x3x1x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        2
+      ],
+      "coeff": "le_1312",
+      "comment": "# Cle1x3x1x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        3
+      ],
+      "coeff": "le_1313",
+      "comment": "# Cle1x3x1x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        1
+      ],
+      "coeff": "le_1321",
+      "comment": "# Cle1x3x2x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        2
+      ],
+      "coeff": "le_1322",
+      "comment": "# Cle1x3x2x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        3
+      ],
+      "coeff": "le_1323",
+      "comment": "# Cle1x3x2x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        1
+      ],
+      "coeff": "le_1331",
+      "comment": "# Cle1x3x3x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        2
+      ],
+      "coeff": "le_1332",
+      "comment": "# Cle1x3x3x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        3
+      ],
+      "coeff": "le_1333",
+      "comment": "# Cle1x3x3x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "coeff": "le_2111",
+      "comment": "# Cle2x1x1x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        2
+      ],
+      "coeff": "le_2112",
+      "comment": "# Cle2x1x1x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        3
+      ],
+      "coeff": "le_2113",
+      "comment": "# Cle2x1x1x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "coeff": "le_2121",
+      "comment": "# Cle2x1x2x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        2
+      ],
+      "coeff": "le_2122",
+      "comment": "# Cle2x1x2x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "coeff": "le_2123",
+      "comment": "# Cle2x1x2x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        1
+      ],
+      "coeff": "le_2131",
+      "comment": "# Cle2x1x3x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        2
+      ],
+      "coeff": "le_2132",
+      "comment": "# Cle2x1x3x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        3
+      ],
+      "coeff": "le_2133",
+      "comment": "# Cle2x1x3x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        1
+      ],
+      "coeff": "le_2211",
+      "comment": "# Cle2x2x1x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        2
+      ],
+      "coeff": "le_2212",
+      "comment": "# Cle2x2x1x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        3
+      ],
+      "coeff": "le_2213",
+      "comment": "# Cle2x2x1x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        1
+      ],
+      "coeff": "le_2221",
+      "comment": "# Cle2x2x2x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "coeff": "le_2222",
+      "comment": "# Cle2x2x2x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        3
+      ],
+      "coeff": "le_2223",
+      "comment": "# Cle2x2x2x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        1
+      ],
+      "coeff": "le_2231",
+      "comment": "# Cle2x2x3x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        2
+      ],
+      "coeff": "le_2232",
+      "comment": "# Cle2x2x3x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        3
+      ],
+      "coeff": "le_2233",
+      "comment": "# Cle2x2x3x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        1
+      ],
+      "coeff": "le_2311",
+      "comment": "# Cle2x3x1x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        2
+      ],
+      "coeff": "le_2312",
+      "comment": "# Cle2x3x1x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        3
+      ],
+      "coeff": "le_2313",
+      "comment": "# Cle2x3x1x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        1
+      ],
+      "coeff": "le_2321",
+      "comment": "# Cle2x3x2x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        2
+      ],
+      "coeff": "le_2322",
+      "comment": "# Cle2x3x2x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        3
+      ],
+      "coeff": "le_2323",
+      "comment": "# Cle2x3x2x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        1
+      ],
+      "coeff": "le_2331",
+      "comment": "# Cle2x3x3x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        2
+      ],
+      "coeff": "le_2332",
+      "comment": "# Cle2x3x3x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        3
+      ],
+      "coeff": "le_2333",
+      "comment": "# Cle2x3x3x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        1
+      ],
+      "coeff": "le_3111",
+      "comment": "# Cle3x1x1x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        2
+      ],
+      "coeff": "le_3112",
+      "comment": "# Cle3x1x1x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        3
+      ],
+      "coeff": "le_3113",
+      "comment": "# Cle3x1x1x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        1
+      ],
+      "coeff": "le_3121",
+      "comment": "# Cle3x1x2x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        2
+      ],
+      "coeff": "le_3122",
+      "comment": "# Cle3x1x2x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        3
+      ],
+      "coeff": "le_3123",
+      "comment": "# Cle3x1x2x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        1
+      ],
+      "coeff": "le_3131",
+      "comment": "# Cle3x1x3x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        2
+      ],
+      "coeff": "le_3132",
+      "comment": "# Cle3x1x3x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        3
+      ],
+      "coeff": "le_3133",
+      "comment": "# Cle3x1x3x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        1
+      ],
+      "coeff": "le_3211",
+      "comment": "# Cle3x2x1x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        2
+      ],
+      "coeff": "le_3212",
+      "comment": "# Cle3x2x1x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        3
+      ],
+      "coeff": "le_3213",
+      "comment": "# Cle3x2x1x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        1
+      ],
+      "coeff": "le_3221",
+      "comment": "# Cle3x2x2x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        2
+      ],
+      "coeff": "le_3222",
+      "comment": "# Cle3x2x2x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        3
+      ],
+      "coeff": "le_3223",
+      "comment": "# Cle3x2x2x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "coeff": "le_3231",
+      "comment": "# Cle3x2x3x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        2
+      ],
+      "coeff": "le_3232",
+      "comment": "# Cle3x2x3x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        3
+      ],
+      "coeff": "le_3233",
+      "comment": "# Cle3x2x3x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        1
+      ],
+      "coeff": "le_3311",
+      "comment": "# Cle3x3x1x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        2
+      ],
+      "coeff": "le_3312",
+      "comment": "# Cle3x3x1x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        3
+      ],
+      "coeff": "le_3313",
+      "comment": "# Cle3x3x1x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        1
+      ],
+      "coeff": "le_3321",
+      "comment": "# Cle3x3x2x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        2
+      ],
+      "coeff": "le_3322",
+      "comment": "# Cle3x3x2x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        3
+      ],
+      "coeff": "le_3323",
+      "comment": "# Cle3x3x2x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        1
+      ],
+      "coeff": "le_3331",
+      "comment": "# Cle3x3x3x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        2
+      ],
+      "coeff": "le_3332",
+      "comment": "# Cle3x3x3x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        3
+      ],
+      "coeff": "le_3333",
+      "comment": "# Cle3x3x3x3 "
+    }
+  ],
+  "frblock32": [
+    {
+      "index": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "coeff": "ledq_1111",
+      "comment": "# Cledq1x1x1x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        2
+      ],
+      "coeff": "ledq_1112",
+      "comment": "# Cledq1x1x1x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        3
+      ],
+      "coeff": "ledq_1113",
+      "comment": "# Cledq1x1x1x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        1
+      ],
+      "coeff": "ledq_1121",
+      "comment": "# Cledq1x1x2x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "coeff": "ledq_1122",
+      "comment": "# Cledq1x1x2x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "coeff": "ledq_1123",
+      "comment": "# Cledq1x1x2x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        1
+      ],
+      "coeff": "ledq_1131",
+      "comment": "# Cledq1x1x3x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        2
+      ],
+      "coeff": "ledq_1132",
+      "comment": "# Cledq1x1x3x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        3
+      ],
+      "coeff": "ledq_1133",
+      "comment": "# Cledq1x1x3x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        1
+      ],
+      "coeff": "ledq_1211",
+      "comment": "# Cledq1x2x1x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        2
+      ],
+      "coeff": "ledq_1212",
+      "comment": "# Cledq1x2x1x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        3
+      ],
+      "coeff": "ledq_1213",
+      "comment": "# Cledq1x2x1x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        1
+      ],
+      "coeff": "ledq_1221",
+      "comment": "# Cledq1x2x2x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        2
+      ],
+      "coeff": "ledq_1222",
+      "comment": "# Cledq1x2x2x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        3
+      ],
+      "coeff": "ledq_1223",
+      "comment": "# Cledq1x2x2x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        1
+      ],
+      "coeff": "ledq_1231",
+      "comment": "# Cledq1x2x3x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        2
+      ],
+      "coeff": "ledq_1232",
+      "comment": "# Cledq1x2x3x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        3
+      ],
+      "coeff": "ledq_1233",
+      "comment": "# Cledq1x2x3x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        1
+      ],
+      "coeff": "ledq_1311",
+      "comment": "# Cledq1x3x1x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        2
+      ],
+      "coeff": "ledq_1312",
+      "comment": "# Cledq1x3x1x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        3
+      ],
+      "coeff": "ledq_1313",
+      "comment": "# Cledq1x3x1x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        1
+      ],
+      "coeff": "ledq_1321",
+      "comment": "# Cledq1x3x2x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        2
+      ],
+      "coeff": "ledq_1322",
+      "comment": "# Cledq1x3x2x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        3
+      ],
+      "coeff": "ledq_1323",
+      "comment": "# Cledq1x3x2x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        1
+      ],
+      "coeff": "ledq_1331",
+      "comment": "# Cledq1x3x3x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        2
+      ],
+      "coeff": "ledq_1332",
+      "comment": "# Cledq1x3x3x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        3
+      ],
+      "coeff": "ledq_1333",
+      "comment": "# Cledq1x3x3x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "coeff": "ledq_2111",
+      "comment": "# Cledq2x1x1x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        2
+      ],
+      "coeff": "ledq_2112",
+      "comment": "# Cledq2x1x1x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        3
+      ],
+      "coeff": "ledq_2113",
+      "comment": "# Cledq2x1x1x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "coeff": "ledq_2121",
+      "comment": "# Cledq2x1x2x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        2
+      ],
+      "coeff": "ledq_2122",
+      "comment": "# Cledq2x1x2x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "coeff": "ledq_2123",
+      "comment": "# Cledq2x1x2x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        1
+      ],
+      "coeff": "ledq_2131",
+      "comment": "# Cledq2x1x3x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        2
+      ],
+      "coeff": "ledq_2132",
+      "comment": "# Cledq2x1x3x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        3
+      ],
+      "coeff": "ledq_2133",
+      "comment": "# Cledq2x1x3x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        1
+      ],
+      "coeff": "ledq_2211",
+      "comment": "# Cledq2x2x1x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        2
+      ],
+      "coeff": "ledq_2212",
+      "comment": "# Cledq2x2x1x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        3
+      ],
+      "coeff": "ledq_2213",
+      "comment": "# Cledq2x2x1x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        1
+      ],
+      "coeff": "ledq_2221",
+      "comment": "# Cledq2x2x2x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "coeff": "ledq_2222",
+      "comment": "# Cledq2x2x2x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        3
+      ],
+      "coeff": "ledq_2223",
+      "comment": "# Cledq2x2x2x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        1
+      ],
+      "coeff": "ledq_2231",
+      "comment": "# Cledq2x2x3x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        2
+      ],
+      "coeff": "ledq_2232",
+      "comment": "# Cledq2x2x3x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        3
+      ],
+      "coeff": "ledq_2233",
+      "comment": "# Cledq2x2x3x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        1
+      ],
+      "coeff": "ledq_2311",
+      "comment": "# Cledq2x3x1x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        2
+      ],
+      "coeff": "ledq_2312",
+      "comment": "# Cledq2x3x1x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        3
+      ],
+      "coeff": "ledq_2313",
+      "comment": "# Cledq2x3x1x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        1
+      ],
+      "coeff": "ledq_2321",
+      "comment": "# Cledq2x3x2x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        2
+      ],
+      "coeff": "ledq_2322",
+      "comment": "# Cledq2x3x2x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        3
+      ],
+      "coeff": "ledq_2323",
+      "comment": "# Cledq2x3x2x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        1
+      ],
+      "coeff": "ledq_2331",
+      "comment": "# Cledq2x3x3x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        2
+      ],
+      "coeff": "ledq_2332",
+      "comment": "# Cledq2x3x3x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        3
+      ],
+      "coeff": "ledq_2333",
+      "comment": "# Cledq2x3x3x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        1
+      ],
+      "coeff": "ledq_3111",
+      "comment": "# Cledq3x1x1x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        2
+      ],
+      "coeff": "ledq_3112",
+      "comment": "# Cledq3x1x1x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        3
+      ],
+      "coeff": "ledq_3113",
+      "comment": "# Cledq3x1x1x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        1
+      ],
+      "coeff": "ledq_3121",
+      "comment": "# Cledq3x1x2x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        2
+      ],
+      "coeff": "ledq_3122",
+      "comment": "# Cledq3x1x2x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        3
+      ],
+      "coeff": "ledq_3123",
+      "comment": "# Cledq3x1x2x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        1
+      ],
+      "coeff": "ledq_3131",
+      "comment": "# Cledq3x1x3x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        2
+      ],
+      "coeff": "ledq_3132",
+      "comment": "# Cledq3x1x3x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        3
+      ],
+      "coeff": "ledq_3133",
+      "comment": "# Cledq3x1x3x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        1
+      ],
+      "coeff": "ledq_3211",
+      "comment": "# Cledq3x2x1x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        2
+      ],
+      "coeff": "ledq_3212",
+      "comment": "# Cledq3x2x1x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        3
+      ],
+      "coeff": "ledq_3213",
+      "comment": "# Cledq3x2x1x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        1
+      ],
+      "coeff": "ledq_3221",
+      "comment": "# Cledq3x2x2x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        2
+      ],
+      "coeff": "ledq_3222",
+      "comment": "# Cledq3x2x2x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        3
+      ],
+      "coeff": "ledq_3223",
+      "comment": "# Cledq3x2x2x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "coeff": "ledq_3231",
+      "comment": "# Cledq3x2x3x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        2
+      ],
+      "coeff": "ledq_3232",
+      "comment": "# Cledq3x2x3x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        3
+      ],
+      "coeff": "ledq_3233",
+      "comment": "# Cledq3x2x3x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        1
+      ],
+      "coeff": "ledq_3311",
+      "comment": "# Cledq3x3x1x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        2
+      ],
+      "coeff": "ledq_3312",
+      "comment": "# Cledq3x3x1x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        3
+      ],
+      "coeff": "ledq_3313",
+      "comment": "# Cledq3x3x1x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        1
+      ],
+      "coeff": "ledq_3321",
+      "comment": "# Cledq3x3x2x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        2
+      ],
+      "coeff": "ledq_3322",
+      "comment": "# Cledq3x3x2x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        3
+      ],
+      "coeff": "ledq_3323",
+      "comment": "# Cledq3x3x2x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        1
+      ],
+      "coeff": "ledq_3331",
+      "comment": "# Cledq3x3x3x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        2
+      ],
+      "coeff": "ledq_3332",
+      "comment": "# Cledq3x3x3x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        3
+      ],
+      "coeff": "ledq_3333",
+      "comment": "# Cledq3x3x3x3 "
+    }
+  ],
+  "frblock33": [
+    {
+      "index": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "coeff": "lequ1_1111",
+      "comment": "# Clequ11x1x1x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        2
+      ],
+      "coeff": "lequ1_1112",
+      "comment": "# Clequ11x1x1x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        3
+      ],
+      "coeff": "lequ1_1113",
+      "comment": "# Clequ11x1x1x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        1
+      ],
+      "coeff": "lequ1_1121",
+      "comment": "# Clequ11x1x2x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "coeff": "lequ1_1122",
+      "comment": "# Clequ11x1x2x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "coeff": "lequ1_1123",
+      "comment": "# Clequ11x1x2x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        1
+      ],
+      "coeff": "lequ1_1131",
+      "comment": "# Clequ11x1x3x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        2
+      ],
+      "coeff": "lequ1_1132",
+      "comment": "# Clequ11x1x3x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        3
+      ],
+      "coeff": "lequ1_1133",
+      "comment": "# Clequ11x1x3x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        1
+      ],
+      "coeff": "lequ1_1211",
+      "comment": "# Clequ11x2x1x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        2
+      ],
+      "coeff": "lequ1_1212",
+      "comment": "# Clequ11x2x1x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        3
+      ],
+      "coeff": "lequ1_1213",
+      "comment": "# Clequ11x2x1x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        1
+      ],
+      "coeff": "lequ1_1221",
+      "comment": "# Clequ11x2x2x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        2
+      ],
+      "coeff": "lequ1_1222",
+      "comment": "# Clequ11x2x2x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        3
+      ],
+      "coeff": "lequ1_1223",
+      "comment": "# Clequ11x2x2x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        1
+      ],
+      "coeff": "lequ1_1231",
+      "comment": "# Clequ11x2x3x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        2
+      ],
+      "coeff": "lequ1_1232",
+      "comment": "# Clequ11x2x3x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        3
+      ],
+      "coeff": "lequ1_1233",
+      "comment": "# Clequ11x2x3x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        1
+      ],
+      "coeff": "lequ1_1311",
+      "comment": "# Clequ11x3x1x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        2
+      ],
+      "coeff": "lequ1_1312",
+      "comment": "# Clequ11x3x1x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        3
+      ],
+      "coeff": "lequ1_1313",
+      "comment": "# Clequ11x3x1x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        1
+      ],
+      "coeff": "lequ1_1321",
+      "comment": "# Clequ11x3x2x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        2
+      ],
+      "coeff": "lequ1_1322",
+      "comment": "# Clequ11x3x2x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        3
+      ],
+      "coeff": "lequ1_1323",
+      "comment": "# Clequ11x3x2x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        1
+      ],
+      "coeff": "lequ1_1331",
+      "comment": "# Clequ11x3x3x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        2
+      ],
+      "coeff": "lequ1_1332",
+      "comment": "# Clequ11x3x3x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        3
+      ],
+      "coeff": "lequ1_1333",
+      "comment": "# Clequ11x3x3x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "coeff": "lequ1_2111",
+      "comment": "# Clequ12x1x1x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        2
+      ],
+      "coeff": "lequ1_2112",
+      "comment": "# Clequ12x1x1x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        3
+      ],
+      "coeff": "lequ1_2113",
+      "comment": "# Clequ12x1x1x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "coeff": "lequ1_2121",
+      "comment": "# Clequ12x1x2x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        2
+      ],
+      "coeff": "lequ1_2122",
+      "comment": "# Clequ12x1x2x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "coeff": "lequ1_2123",
+      "comment": "# Clequ12x1x2x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        1
+      ],
+      "coeff": "lequ1_2131",
+      "comment": "# Clequ12x1x3x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        2
+      ],
+      "coeff": "lequ1_2132",
+      "comment": "# Clequ12x1x3x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        3
+      ],
+      "coeff": "lequ1_2133",
+      "comment": "# Clequ12x1x3x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        1
+      ],
+      "coeff": "lequ1_2211",
+      "comment": "# Clequ12x2x1x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        2
+      ],
+      "coeff": "lequ1_2212",
+      "comment": "# Clequ12x2x1x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        3
+      ],
+      "coeff": "lequ1_2213",
+      "comment": "# Clequ12x2x1x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        1
+      ],
+      "coeff": "lequ1_2221",
+      "comment": "# Clequ12x2x2x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "coeff": "lequ1_2222",
+      "comment": "# Clequ12x2x2x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        3
+      ],
+      "coeff": "lequ1_2223",
+      "comment": "# Clequ12x2x2x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        1
+      ],
+      "coeff": "lequ1_2231",
+      "comment": "# Clequ12x2x3x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        2
+      ],
+      "coeff": "lequ1_2232",
+      "comment": "# Clequ12x2x3x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        3
+      ],
+      "coeff": "lequ1_2233",
+      "comment": "# Clequ12x2x3x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        1
+      ],
+      "coeff": "lequ1_2311",
+      "comment": "# Clequ12x3x1x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        2
+      ],
+      "coeff": "lequ1_2312",
+      "comment": "# Clequ12x3x1x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        3
+      ],
+      "coeff": "lequ1_2313",
+      "comment": "# Clequ12x3x1x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        1
+      ],
+      "coeff": "lequ1_2321",
+      "comment": "# Clequ12x3x2x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        2
+      ],
+      "coeff": "lequ1_2322",
+      "comment": "# Clequ12x3x2x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        3
+      ],
+      "coeff": "lequ1_2323",
+      "comment": "# Clequ12x3x2x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        1
+      ],
+      "coeff": "lequ1_2331",
+      "comment": "# Clequ12x3x3x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        2
+      ],
+      "coeff": "lequ1_2332",
+      "comment": "# Clequ12x3x3x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        3
+      ],
+      "coeff": "lequ1_2333",
+      "comment": "# Clequ12x3x3x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        1
+      ],
+      "coeff": "lequ1_3111",
+      "comment": "# Clequ13x1x1x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        2
+      ],
+      "coeff": "lequ1_3112",
+      "comment": "# Clequ13x1x1x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        3
+      ],
+      "coeff": "lequ1_3113",
+      "comment": "# Clequ13x1x1x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        1
+      ],
+      "coeff": "lequ1_3121",
+      "comment": "# Clequ13x1x2x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        2
+      ],
+      "coeff": "lequ1_3122",
+      "comment": "# Clequ13x1x2x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        3
+      ],
+      "coeff": "lequ1_3123",
+      "comment": "# Clequ13x1x2x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        1
+      ],
+      "coeff": "lequ1_3131",
+      "comment": "# Clequ13x1x3x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        2
+      ],
+      "coeff": "lequ1_3132",
+      "comment": "# Clequ13x1x3x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        3
+      ],
+      "coeff": "lequ1_3133",
+      "comment": "# Clequ13x1x3x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        1
+      ],
+      "coeff": "lequ1_3211",
+      "comment": "# Clequ13x2x1x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        2
+      ],
+      "coeff": "lequ1_3212",
+      "comment": "# Clequ13x2x1x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        3
+      ],
+      "coeff": "lequ1_3213",
+      "comment": "# Clequ13x2x1x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        1
+      ],
+      "coeff": "lequ1_3221",
+      "comment": "# Clequ13x2x2x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        2
+      ],
+      "coeff": "lequ1_3222",
+      "comment": "# Clequ13x2x2x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        3
+      ],
+      "coeff": "lequ1_3223",
+      "comment": "# Clequ13x2x2x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "coeff": "lequ1_3231",
+      "comment": "# Clequ13x2x3x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        2
+      ],
+      "coeff": "lequ1_3232",
+      "comment": "# Clequ13x2x3x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        3
+      ],
+      "coeff": "lequ1_3233",
+      "comment": "# Clequ13x2x3x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        1
+      ],
+      "coeff": "lequ1_3311",
+      "comment": "# Clequ13x3x1x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        2
+      ],
+      "coeff": "lequ1_3312",
+      "comment": "# Clequ13x3x1x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        3
+      ],
+      "coeff": "lequ1_3313",
+      "comment": "# Clequ13x3x1x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        1
+      ],
+      "coeff": "lequ1_3321",
+      "comment": "# Clequ13x3x2x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        2
+      ],
+      "coeff": "lequ1_3322",
+      "comment": "# Clequ13x3x2x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        3
+      ],
+      "coeff": "lequ1_3323",
+      "comment": "# Clequ13x3x2x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        1
+      ],
+      "coeff": "lequ1_3331",
+      "comment": "# Clequ13x3x3x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        2
+      ],
+      "coeff": "lequ1_3332",
+      "comment": "# Clequ13x3x3x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        3
+      ],
+      "coeff": "lequ1_3333",
+      "comment": "# Clequ13x3x3x3 "
+    }
+  ],
+  "frblock34": [
+    {
+      "index": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "coeff": "lequ3_1111",
+      "comment": "# Clequ31x1x1x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        2
+      ],
+      "coeff": "lequ3_1112",
+      "comment": "# Clequ31x1x1x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        3
+      ],
+      "coeff": "lequ3_1113",
+      "comment": "# Clequ31x1x1x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        1
+      ],
+      "coeff": "lequ3_1121",
+      "comment": "# Clequ31x1x2x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "coeff": "lequ3_1122",
+      "comment": "# Clequ31x1x2x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "coeff": "lequ3_1123",
+      "comment": "# Clequ31x1x2x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        1
+      ],
+      "coeff": "lequ3_1131",
+      "comment": "# Clequ31x1x3x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        2
+      ],
+      "coeff": "lequ3_1132",
+      "comment": "# Clequ31x1x3x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        3
+      ],
+      "coeff": "lequ3_1133",
+      "comment": "# Clequ31x1x3x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        1
+      ],
+      "coeff": "lequ3_1211",
+      "comment": "# Clequ31x2x1x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        2
+      ],
+      "coeff": "lequ3_1212",
+      "comment": "# Clequ31x2x1x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        3
+      ],
+      "coeff": "lequ3_1213",
+      "comment": "# Clequ31x2x1x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        1
+      ],
+      "coeff": "lequ3_1221",
+      "comment": "# Clequ31x2x2x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        2
+      ],
+      "coeff": "lequ3_1222",
+      "comment": "# Clequ31x2x2x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        3
+      ],
+      "coeff": "lequ3_1223",
+      "comment": "# Clequ31x2x2x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        1
+      ],
+      "coeff": "lequ3_1231",
+      "comment": "# Clequ31x2x3x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        2
+      ],
+      "coeff": "lequ3_1232",
+      "comment": "# Clequ31x2x3x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        3
+      ],
+      "coeff": "lequ3_1233",
+      "comment": "# Clequ31x2x3x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        1
+      ],
+      "coeff": "lequ3_1311",
+      "comment": "# Clequ31x3x1x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        2
+      ],
+      "coeff": "lequ3_1312",
+      "comment": "# Clequ31x3x1x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        3
+      ],
+      "coeff": "lequ3_1313",
+      "comment": "# Clequ31x3x1x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        1
+      ],
+      "coeff": "lequ3_1321",
+      "comment": "# Clequ31x3x2x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        2
+      ],
+      "coeff": "lequ3_1322",
+      "comment": "# Clequ31x3x2x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        3
+      ],
+      "coeff": "lequ3_1323",
+      "comment": "# Clequ31x3x2x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        1
+      ],
+      "coeff": "lequ3_1331",
+      "comment": "# Clequ31x3x3x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        2
+      ],
+      "coeff": "lequ3_1332",
+      "comment": "# Clequ31x3x3x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        3
+      ],
+      "coeff": "lequ3_1333",
+      "comment": "# Clequ31x3x3x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "coeff": "lequ3_2111",
+      "comment": "# Clequ32x1x1x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        2
+      ],
+      "coeff": "lequ3_2112",
+      "comment": "# Clequ32x1x1x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        3
+      ],
+      "coeff": "lequ3_2113",
+      "comment": "# Clequ32x1x1x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "coeff": "lequ3_2121",
+      "comment": "# Clequ32x1x2x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        2
+      ],
+      "coeff": "lequ3_2122",
+      "comment": "# Clequ32x1x2x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "coeff": "lequ3_2123",
+      "comment": "# Clequ32x1x2x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        1
+      ],
+      "coeff": "lequ3_2131",
+      "comment": "# Clequ32x1x3x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        2
+      ],
+      "coeff": "lequ3_2132",
+      "comment": "# Clequ32x1x3x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        3
+      ],
+      "coeff": "lequ3_2133",
+      "comment": "# Clequ32x1x3x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        1
+      ],
+      "coeff": "lequ3_2211",
+      "comment": "# Clequ32x2x1x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        2
+      ],
+      "coeff": "lequ3_2212",
+      "comment": "# Clequ32x2x1x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        3
+      ],
+      "coeff": "lequ3_2213",
+      "comment": "# Clequ32x2x1x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        1
+      ],
+      "coeff": "lequ3_2221",
+      "comment": "# Clequ32x2x2x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "coeff": "lequ3_2222",
+      "comment": "# Clequ32x2x2x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        3
+      ],
+      "coeff": "lequ3_2223",
+      "comment": "# Clequ32x2x2x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        1
+      ],
+      "coeff": "lequ3_2231",
+      "comment": "# Clequ32x2x3x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        2
+      ],
+      "coeff": "lequ3_2232",
+      "comment": "# Clequ32x2x3x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        3
+      ],
+      "coeff": "lequ3_2233",
+      "comment": "# Clequ32x2x3x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        1
+      ],
+      "coeff": "lequ3_2311",
+      "comment": "# Clequ32x3x1x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        2
+      ],
+      "coeff": "lequ3_2312",
+      "comment": "# Clequ32x3x1x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        3
+      ],
+      "coeff": "lequ3_2313",
+      "comment": "# Clequ32x3x1x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        1
+      ],
+      "coeff": "lequ3_2321",
+      "comment": "# Clequ32x3x2x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        2
+      ],
+      "coeff": "lequ3_2322",
+      "comment": "# Clequ32x3x2x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        3
+      ],
+      "coeff": "lequ3_2323",
+      "comment": "# Clequ32x3x2x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        1
+      ],
+      "coeff": "lequ3_2331",
+      "comment": "# Clequ32x3x3x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        2
+      ],
+      "coeff": "lequ3_2332",
+      "comment": "# Clequ32x3x3x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        3
+      ],
+      "coeff": "lequ3_2333",
+      "comment": "# Clequ32x3x3x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        1
+      ],
+      "coeff": "lequ3_3111",
+      "comment": "# Clequ33x1x1x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        2
+      ],
+      "coeff": "lequ3_3112",
+      "comment": "# Clequ33x1x1x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        3
+      ],
+      "coeff": "lequ3_3113",
+      "comment": "# Clequ33x1x1x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        1
+      ],
+      "coeff": "lequ3_3121",
+      "comment": "# Clequ33x1x2x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        2
+      ],
+      "coeff": "lequ3_3122",
+      "comment": "# Clequ33x1x2x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        3
+      ],
+      "coeff": "lequ3_3123",
+      "comment": "# Clequ33x1x2x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        1
+      ],
+      "coeff": "lequ3_3131",
+      "comment": "# Clequ33x1x3x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        2
+      ],
+      "coeff": "lequ3_3132",
+      "comment": "# Clequ33x1x3x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        3
+      ],
+      "coeff": "lequ3_3133",
+      "comment": "# Clequ33x1x3x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        1
+      ],
+      "coeff": "lequ3_3211",
+      "comment": "# Clequ33x2x1x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        2
+      ],
+      "coeff": "lequ3_3212",
+      "comment": "# Clequ33x2x1x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        3
+      ],
+      "coeff": "lequ3_3213",
+      "comment": "# Clequ33x2x1x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        1
+      ],
+      "coeff": "lequ3_3221",
+      "comment": "# Clequ33x2x2x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        2
+      ],
+      "coeff": "lequ3_3222",
+      "comment": "# Clequ33x2x2x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        3
+      ],
+      "coeff": "lequ3_3223",
+      "comment": "# Clequ33x2x2x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "coeff": "lequ3_3231",
+      "comment": "# Clequ33x2x3x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        2
+      ],
+      "coeff": "lequ3_3232",
+      "comment": "# Clequ33x2x3x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        3
+      ],
+      "coeff": "lequ3_3233",
+      "comment": "# Clequ33x2x3x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        1
+      ],
+      "coeff": "lequ3_3311",
+      "comment": "# Clequ33x3x1x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        2
+      ],
+      "coeff": "lequ3_3312",
+      "comment": "# Clequ33x3x1x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        3
+      ],
+      "coeff": "lequ3_3313",
+      "comment": "# Clequ33x3x1x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        1
+      ],
+      "coeff": "lequ3_3321",
+      "comment": "# Clequ33x3x2x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        2
+      ],
+      "coeff": "lequ3_3322",
+      "comment": "# Clequ33x3x2x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        3
+      ],
+      "coeff": "lequ3_3323",
+      "comment": "# Clequ33x3x2x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        1
+      ],
+      "coeff": "lequ3_3331",
+      "comment": "# Clequ33x3x3x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        2
+      ],
+      "coeff": "lequ3_3332",
+      "comment": "# Clequ33x3x3x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        3
+      ],
+      "coeff": "lequ3_3333",
+      "comment": "# Clequ33x3x3x3 "
+    }
+  ],
+  "frblock35": [
+    {
+      "index": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "coeff": "ll_1111",
+      "comment": "# Cll1x1x1x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        2
+      ],
+      "coeff": "ll_1112",
+      "comment": "# Cll1x1x1x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        3
+      ],
+      "coeff": "ll_1113",
+      "comment": "# Cll1x1x1x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        1
+      ],
+      "coeff": "ll_1121",
+      "comment": "# Cll1x1x2x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "coeff": "ll_1122",
+      "comment": "# Cll1x1x2x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "coeff": "ll_1123",
+      "comment": "# Cll1x1x2x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        1
+      ],
+      "coeff": "ll_1131",
+      "comment": "# Cll1x1x3x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        2
+      ],
+      "coeff": "ll_1132",
+      "comment": "# Cll1x1x3x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        3
+      ],
+      "coeff": "ll_1133",
+      "comment": "# Cll1x1x3x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        1
+      ],
+      "coeff": "ll_1211",
+      "comment": "# Cll1x2x1x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        2
+      ],
+      "coeff": "ll_1212",
+      "comment": "# Cll1x2x1x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        3
+      ],
+      "coeff": "ll_1213",
+      "comment": "# Cll1x2x1x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        1
+      ],
+      "coeff": "ll_1221",
+      "comment": "# Cll1x2x2x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        2
+      ],
+      "coeff": "ll_1222",
+      "comment": "# Cll1x2x2x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        3
+      ],
+      "coeff": "ll_1223",
+      "comment": "# Cll1x2x2x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        1
+      ],
+      "coeff": "ll_1231",
+      "comment": "# Cll1x2x3x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        2
+      ],
+      "coeff": "ll_1232",
+      "comment": "# Cll1x2x3x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        3
+      ],
+      "coeff": "ll_1233",
+      "comment": "# Cll1x2x3x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        1
+      ],
+      "coeff": "ll_1311",
+      "comment": "# Cll1x3x1x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        2
+      ],
+      "coeff": "ll_1312",
+      "comment": "# Cll1x3x1x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        3
+      ],
+      "coeff": "ll_1313",
+      "comment": "# Cll1x3x1x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        1
+      ],
+      "coeff": "ll_1321",
+      "comment": "# Cll1x3x2x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        2
+      ],
+      "coeff": "ll_1322",
+      "comment": "# Cll1x3x2x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        3
+      ],
+      "coeff": "ll_1323",
+      "comment": "# Cll1x3x2x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        1
+      ],
+      "coeff": "ll_1331",
+      "comment": "# Cll1x3x3x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        2
+      ],
+      "coeff": "ll_1332",
+      "comment": "# Cll1x3x3x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        3
+      ],
+      "coeff": "ll_1333",
+      "comment": "# Cll1x3x3x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "coeff": "ll_2111",
+      "comment": "# Cll2x1x1x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        2
+      ],
+      "coeff": "ll_2112",
+      "comment": "# Cll2x1x1x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        3
+      ],
+      "coeff": "ll_2113",
+      "comment": "# Cll2x1x1x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "coeff": "ll_2121",
+      "comment": "# Cll2x1x2x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        2
+      ],
+      "coeff": "ll_2122",
+      "comment": "# Cll2x1x2x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "coeff": "ll_2123",
+      "comment": "# Cll2x1x2x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        1
+      ],
+      "coeff": "ll_2131",
+      "comment": "# Cll2x1x3x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        2
+      ],
+      "coeff": "ll_2132",
+      "comment": "# Cll2x1x3x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        3
+      ],
+      "coeff": "ll_2133",
+      "comment": "# Cll2x1x3x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        1
+      ],
+      "coeff": "ll_2211",
+      "comment": "# Cll2x2x1x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        2
+      ],
+      "coeff": "ll_2212",
+      "comment": "# Cll2x2x1x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        3
+      ],
+      "coeff": "ll_2213",
+      "comment": "# Cll2x2x1x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        1
+      ],
+      "coeff": "ll_2221",
+      "comment": "# Cll2x2x2x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "coeff": "ll_2222",
+      "comment": "# Cll2x2x2x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        3
+      ],
+      "coeff": "ll_2223",
+      "comment": "# Cll2x2x2x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        1
+      ],
+      "coeff": "ll_2231",
+      "comment": "# Cll2x2x3x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        2
+      ],
+      "coeff": "ll_2232",
+      "comment": "# Cll2x2x3x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        3
+      ],
+      "coeff": "ll_2233",
+      "comment": "# Cll2x2x3x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        1
+      ],
+      "coeff": "ll_2311",
+      "comment": "# Cll2x3x1x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        2
+      ],
+      "coeff": "ll_2312",
+      "comment": "# Cll2x3x1x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        3
+      ],
+      "coeff": "ll_2313",
+      "comment": "# Cll2x3x1x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        1
+      ],
+      "coeff": "ll_2321",
+      "comment": "# Cll2x3x2x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        2
+      ],
+      "coeff": "ll_2322",
+      "comment": "# Cll2x3x2x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        3
+      ],
+      "coeff": "ll_2323",
+      "comment": "# Cll2x3x2x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        1
+      ],
+      "coeff": "ll_2331",
+      "comment": "# Cll2x3x3x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        2
+      ],
+      "coeff": "ll_2332",
+      "comment": "# Cll2x3x3x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        3
+      ],
+      "coeff": "ll_2333",
+      "comment": "# Cll2x3x3x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        1
+      ],
+      "coeff": "ll_3111",
+      "comment": "# Cll3x1x1x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        2
+      ],
+      "coeff": "ll_3112",
+      "comment": "# Cll3x1x1x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        3
+      ],
+      "coeff": "ll_3113",
+      "comment": "# Cll3x1x1x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        1
+      ],
+      "coeff": "ll_3121",
+      "comment": "# Cll3x1x2x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        2
+      ],
+      "coeff": "ll_3122",
+      "comment": "# Cll3x1x2x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        3
+      ],
+      "coeff": "ll_3123",
+      "comment": "# Cll3x1x2x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        1
+      ],
+      "coeff": "ll_3131",
+      "comment": "# Cll3x1x3x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        2
+      ],
+      "coeff": "ll_3132",
+      "comment": "# Cll3x1x3x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        3
+      ],
+      "coeff": "ll_3133",
+      "comment": "# Cll3x1x3x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        1
+      ],
+      "coeff": "ll_3211",
+      "comment": "# Cll3x2x1x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        2
+      ],
+      "coeff": "ll_3212",
+      "comment": "# Cll3x2x1x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        3
+      ],
+      "coeff": "ll_3213",
+      "comment": "# Cll3x2x1x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        1
+      ],
+      "coeff": "ll_3221",
+      "comment": "# Cll3x2x2x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        2
+      ],
+      "coeff": "ll_3222",
+      "comment": "# Cll3x2x2x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        3
+      ],
+      "coeff": "ll_3223",
+      "comment": "# Cll3x2x2x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "coeff": "ll_3231",
+      "comment": "# Cll3x2x3x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        2
+      ],
+      "coeff": "ll_3232",
+      "comment": "# Cll3x2x3x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        3
+      ],
+      "coeff": "ll_3233",
+      "comment": "# Cll3x2x3x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        1
+      ],
+      "coeff": "ll_3311",
+      "comment": "# Cll3x3x1x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        2
+      ],
+      "coeff": "ll_3312",
+      "comment": "# Cll3x3x1x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        3
+      ],
+      "coeff": "ll_3313",
+      "comment": "# Cll3x3x1x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        1
+      ],
+      "coeff": "ll_3321",
+      "comment": "# Cll3x3x2x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        2
+      ],
+      "coeff": "ll_3322",
+      "comment": "# Cll3x3x2x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        3
+      ],
+      "coeff": "ll_3323",
+      "comment": "# Cll3x3x2x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        1
+      ],
+      "coeff": "ll_3331",
+      "comment": "# Cll3x3x3x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        2
+      ],
+      "coeff": "ll_3332",
+      "comment": "# Cll3x3x3x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        3
+      ],
+      "coeff": "ll_3333",
+      "comment": "# Cll3x3x3x3 "
+    }
+  ],
+  "frblock36": [
+    {
+      "index": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "coeff": "lq1_1111",
+      "comment": "# Clq11x1x1x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        2
+      ],
+      "coeff": "lq1_1112",
+      "comment": "# Clq11x1x1x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        3
+      ],
+      "coeff": "lq1_1113",
+      "comment": "# Clq11x1x1x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        1
+      ],
+      "coeff": "lq1_1121",
+      "comment": "# Clq11x1x2x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "coeff": "lq1_1122",
+      "comment": "# Clq11x1x2x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "coeff": "lq1_1123",
+      "comment": "# Clq11x1x2x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        1
+      ],
+      "coeff": "lq1_1131",
+      "comment": "# Clq11x1x3x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        2
+      ],
+      "coeff": "lq1_1132",
+      "comment": "# Clq11x1x3x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        3
+      ],
+      "coeff": "lq1_1133",
+      "comment": "# Clq11x1x3x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        1
+      ],
+      "coeff": "lq1_1211",
+      "comment": "# Clq11x2x1x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        2
+      ],
+      "coeff": "lq1_1212",
+      "comment": "# Clq11x2x1x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        3
+      ],
+      "coeff": "lq1_1213",
+      "comment": "# Clq11x2x1x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        1
+      ],
+      "coeff": "lq1_1221",
+      "comment": "# Clq11x2x2x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        2
+      ],
+      "coeff": "lq1_1222",
+      "comment": "# Clq11x2x2x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        3
+      ],
+      "coeff": "lq1_1223",
+      "comment": "# Clq11x2x2x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        1
+      ],
+      "coeff": "lq1_1231",
+      "comment": "# Clq11x2x3x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        2
+      ],
+      "coeff": "lq1_1232",
+      "comment": "# Clq11x2x3x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        3
+      ],
+      "coeff": "lq1_1233",
+      "comment": "# Clq11x2x3x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        1
+      ],
+      "coeff": "lq1_1311",
+      "comment": "# Clq11x3x1x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        2
+      ],
+      "coeff": "lq1_1312",
+      "comment": "# Clq11x3x1x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        3
+      ],
+      "coeff": "lq1_1313",
+      "comment": "# Clq11x3x1x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        1
+      ],
+      "coeff": "lq1_1321",
+      "comment": "# Clq11x3x2x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        2
+      ],
+      "coeff": "lq1_1322",
+      "comment": "# Clq11x3x2x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        3
+      ],
+      "coeff": "lq1_1323",
+      "comment": "# Clq11x3x2x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        1
+      ],
+      "coeff": "lq1_1331",
+      "comment": "# Clq11x3x3x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        2
+      ],
+      "coeff": "lq1_1332",
+      "comment": "# Clq11x3x3x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        3
+      ],
+      "coeff": "lq1_1333",
+      "comment": "# Clq11x3x3x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "coeff": "lq1_2111",
+      "comment": "# Clq12x1x1x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        2
+      ],
+      "coeff": "lq1_2112",
+      "comment": "# Clq12x1x1x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        3
+      ],
+      "coeff": "lq1_2113",
+      "comment": "# Clq12x1x1x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "coeff": "lq1_2121",
+      "comment": "# Clq12x1x2x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        2
+      ],
+      "coeff": "lq1_2122",
+      "comment": "# Clq12x1x2x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "coeff": "lq1_2123",
+      "comment": "# Clq12x1x2x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        1
+      ],
+      "coeff": "lq1_2131",
+      "comment": "# Clq12x1x3x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        2
+      ],
+      "coeff": "lq1_2132",
+      "comment": "# Clq12x1x3x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        3
+      ],
+      "coeff": "lq1_2133",
+      "comment": "# Clq12x1x3x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        1
+      ],
+      "coeff": "lq1_2211",
+      "comment": "# Clq12x2x1x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        2
+      ],
+      "coeff": "lq1_2212",
+      "comment": "# Clq12x2x1x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        3
+      ],
+      "coeff": "lq1_2213",
+      "comment": "# Clq12x2x1x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        1
+      ],
+      "coeff": "lq1_2221",
+      "comment": "# Clq12x2x2x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "coeff": "lq1_2222",
+      "comment": "# Clq12x2x2x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        3
+      ],
+      "coeff": "lq1_2223",
+      "comment": "# Clq12x2x2x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        1
+      ],
+      "coeff": "lq1_2231",
+      "comment": "# Clq12x2x3x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        2
+      ],
+      "coeff": "lq1_2232",
+      "comment": "# Clq12x2x3x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        3
+      ],
+      "coeff": "lq1_2233",
+      "comment": "# Clq12x2x3x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        1
+      ],
+      "coeff": "lq1_2311",
+      "comment": "# Clq12x3x1x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        2
+      ],
+      "coeff": "lq1_2312",
+      "comment": "# Clq12x3x1x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        3
+      ],
+      "coeff": "lq1_2313",
+      "comment": "# Clq12x3x1x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        1
+      ],
+      "coeff": "lq1_2321",
+      "comment": "# Clq12x3x2x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        2
+      ],
+      "coeff": "lq1_2322",
+      "comment": "# Clq12x3x2x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        3
+      ],
+      "coeff": "lq1_2323",
+      "comment": "# Clq12x3x2x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        1
+      ],
+      "coeff": "lq1_2331",
+      "comment": "# Clq12x3x3x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        2
+      ],
+      "coeff": "lq1_2332",
+      "comment": "# Clq12x3x3x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        3
+      ],
+      "coeff": "lq1_2333",
+      "comment": "# Clq12x3x3x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        1
+      ],
+      "coeff": "lq1_3111",
+      "comment": "# Clq13x1x1x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        2
+      ],
+      "coeff": "lq1_3112",
+      "comment": "# Clq13x1x1x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        3
+      ],
+      "coeff": "lq1_3113",
+      "comment": "# Clq13x1x1x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        1
+      ],
+      "coeff": "lq1_3121",
+      "comment": "# Clq13x1x2x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        2
+      ],
+      "coeff": "lq1_3122",
+      "comment": "# Clq13x1x2x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        3
+      ],
+      "coeff": "lq1_3123",
+      "comment": "# Clq13x1x2x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        1
+      ],
+      "coeff": "lq1_3131",
+      "comment": "# Clq13x1x3x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        2
+      ],
+      "coeff": "lq1_3132",
+      "comment": "# Clq13x1x3x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        3
+      ],
+      "coeff": "lq1_3133",
+      "comment": "# Clq13x1x3x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        1
+      ],
+      "coeff": "lq1_3211",
+      "comment": "# Clq13x2x1x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        2
+      ],
+      "coeff": "lq1_3212",
+      "comment": "# Clq13x2x1x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        3
+      ],
+      "coeff": "lq1_3213",
+      "comment": "# Clq13x2x1x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        1
+      ],
+      "coeff": "lq1_3221",
+      "comment": "# Clq13x2x2x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        2
+      ],
+      "coeff": "lq1_3222",
+      "comment": "# Clq13x2x2x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        3
+      ],
+      "coeff": "lq1_3223",
+      "comment": "# Clq13x2x2x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "coeff": "lq1_3231",
+      "comment": "# Clq13x2x3x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        2
+      ],
+      "coeff": "lq1_3232",
+      "comment": "# Clq13x2x3x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        3
+      ],
+      "coeff": "lq1_3233",
+      "comment": "# Clq13x2x3x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        1
+      ],
+      "coeff": "lq1_3311",
+      "comment": "# Clq13x3x1x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        2
+      ],
+      "coeff": "lq1_3312",
+      "comment": "# Clq13x3x1x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        3
+      ],
+      "coeff": "lq1_3313",
+      "comment": "# Clq13x3x1x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        1
+      ],
+      "coeff": "lq1_3321",
+      "comment": "# Clq13x3x2x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        2
+      ],
+      "coeff": "lq1_3322",
+      "comment": "# Clq13x3x2x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        3
+      ],
+      "coeff": "lq1_3323",
+      "comment": "# Clq13x3x2x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        1
+      ],
+      "coeff": "lq1_3331",
+      "comment": "# Clq13x3x3x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        2
+      ],
+      "coeff": "lq1_3332",
+      "comment": "# Clq13x3x3x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        3
+      ],
+      "coeff": "lq1_3333",
+      "comment": "# Clq13x3x3x3 "
+    }
+  ],
+  "frblock37": [
+    {
+      "index": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "coeff": "lq3_1111",
+      "comment": "# Clq31x1x1x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        2
+      ],
+      "coeff": "lq3_1112",
+      "comment": "# Clq31x1x1x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        3
+      ],
+      "coeff": "lq3_1113",
+      "comment": "# Clq31x1x1x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        1
+      ],
+      "coeff": "lq3_1121",
+      "comment": "# Clq31x1x2x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "coeff": "lq3_1122",
+      "comment": "# Clq31x1x2x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "coeff": "lq3_1123",
+      "comment": "# Clq31x1x2x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        1
+      ],
+      "coeff": "lq3_1131",
+      "comment": "# Clq31x1x3x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        2
+      ],
+      "coeff": "lq3_1132",
+      "comment": "# Clq31x1x3x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        3
+      ],
+      "coeff": "lq3_1133",
+      "comment": "# Clq31x1x3x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        1
+      ],
+      "coeff": "lq3_1211",
+      "comment": "# Clq31x2x1x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        2
+      ],
+      "coeff": "lq3_1212",
+      "comment": "# Clq31x2x1x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        3
+      ],
+      "coeff": "lq3_1213",
+      "comment": "# Clq31x2x1x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        1
+      ],
+      "coeff": "lq3_1221",
+      "comment": "# Clq31x2x2x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        2
+      ],
+      "coeff": "lq3_1222",
+      "comment": "# Clq31x2x2x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        3
+      ],
+      "coeff": "lq3_1223",
+      "comment": "# Clq31x2x2x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        1
+      ],
+      "coeff": "lq3_1231",
+      "comment": "# Clq31x2x3x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        2
+      ],
+      "coeff": "lq3_1232",
+      "comment": "# Clq31x2x3x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        3
+      ],
+      "coeff": "lq3_1233",
+      "comment": "# Clq31x2x3x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        1
+      ],
+      "coeff": "lq3_1311",
+      "comment": "# Clq31x3x1x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        2
+      ],
+      "coeff": "lq3_1312",
+      "comment": "# Clq31x3x1x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        3
+      ],
+      "coeff": "lq3_1313",
+      "comment": "# Clq31x3x1x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        1
+      ],
+      "coeff": "lq3_1321",
+      "comment": "# Clq31x3x2x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        2
+      ],
+      "coeff": "lq3_1322",
+      "comment": "# Clq31x3x2x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        3
+      ],
+      "coeff": "lq3_1323",
+      "comment": "# Clq31x3x2x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        1
+      ],
+      "coeff": "lq3_1331",
+      "comment": "# Clq31x3x3x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        2
+      ],
+      "coeff": "lq3_1332",
+      "comment": "# Clq31x3x3x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        3
+      ],
+      "coeff": "lq3_1333",
+      "comment": "# Clq31x3x3x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "coeff": "lq3_2111",
+      "comment": "# Clq32x1x1x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        2
+      ],
+      "coeff": "lq3_2112",
+      "comment": "# Clq32x1x1x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        3
+      ],
+      "coeff": "lq3_2113",
+      "comment": "# Clq32x1x1x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "coeff": "lq3_2121",
+      "comment": "# Clq32x1x2x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        2
+      ],
+      "coeff": "lq3_2122",
+      "comment": "# Clq32x1x2x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "coeff": "lq3_2123",
+      "comment": "# Clq32x1x2x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        1
+      ],
+      "coeff": "lq3_2131",
+      "comment": "# Clq32x1x3x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        2
+      ],
+      "coeff": "lq3_2132",
+      "comment": "# Clq32x1x3x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        3
+      ],
+      "coeff": "lq3_2133",
+      "comment": "# Clq32x1x3x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        1
+      ],
+      "coeff": "lq3_2211",
+      "comment": "# Clq32x2x1x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        2
+      ],
+      "coeff": "lq3_2212",
+      "comment": "# Clq32x2x1x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        3
+      ],
+      "coeff": "lq3_2213",
+      "comment": "# Clq32x2x1x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        1
+      ],
+      "coeff": "lq3_2221",
+      "comment": "# Clq32x2x2x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "coeff": "lq3_2222",
+      "comment": "# Clq32x2x2x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        3
+      ],
+      "coeff": "lq3_2223",
+      "comment": "# Clq32x2x2x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        1
+      ],
+      "coeff": "lq3_2231",
+      "comment": "# Clq32x2x3x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        2
+      ],
+      "coeff": "lq3_2232",
+      "comment": "# Clq32x2x3x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        3
+      ],
+      "coeff": "lq3_2233",
+      "comment": "# Clq32x2x3x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        1
+      ],
+      "coeff": "lq3_2311",
+      "comment": "# Clq32x3x1x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        2
+      ],
+      "coeff": "lq3_2312",
+      "comment": "# Clq32x3x1x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        3
+      ],
+      "coeff": "lq3_2313",
+      "comment": "# Clq32x3x1x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        1
+      ],
+      "coeff": "lq3_2321",
+      "comment": "# Clq32x3x2x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        2
+      ],
+      "coeff": "lq3_2322",
+      "comment": "# Clq32x3x2x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        3
+      ],
+      "coeff": "lq3_2323",
+      "comment": "# Clq32x3x2x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        1
+      ],
+      "coeff": "lq3_2331",
+      "comment": "# Clq32x3x3x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        2
+      ],
+      "coeff": "lq3_2332",
+      "comment": "# Clq32x3x3x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        3
+      ],
+      "coeff": "lq3_2333",
+      "comment": "# Clq32x3x3x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        1
+      ],
+      "coeff": "lq3_3111",
+      "comment": "# Clq33x1x1x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        2
+      ],
+      "coeff": "lq3_3112",
+      "comment": "# Clq33x1x1x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        3
+      ],
+      "coeff": "lq3_3113",
+      "comment": "# Clq33x1x1x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        1
+      ],
+      "coeff": "lq3_3121",
+      "comment": "# Clq33x1x2x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        2
+      ],
+      "coeff": "lq3_3122",
+      "comment": "# Clq33x1x2x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        3
+      ],
+      "coeff": "lq3_3123",
+      "comment": "# Clq33x1x2x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        1
+      ],
+      "coeff": "lq3_3131",
+      "comment": "# Clq33x1x3x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        2
+      ],
+      "coeff": "lq3_3132",
+      "comment": "# Clq33x1x3x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        3
+      ],
+      "coeff": "lq3_3133",
+      "comment": "# Clq33x1x3x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        1
+      ],
+      "coeff": "lq3_3211",
+      "comment": "# Clq33x2x1x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        2
+      ],
+      "coeff": "lq3_3212",
+      "comment": "# Clq33x2x1x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        3
+      ],
+      "coeff": "lq3_3213",
+      "comment": "# Clq33x2x1x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        1
+      ],
+      "coeff": "lq3_3221",
+      "comment": "# Clq33x2x2x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        2
+      ],
+      "coeff": "lq3_3222",
+      "comment": "# Clq33x2x2x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        3
+      ],
+      "coeff": "lq3_3223",
+      "comment": "# Clq33x2x2x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "coeff": "lq3_3231",
+      "comment": "# Clq33x2x3x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        2
+      ],
+      "coeff": "lq3_3232",
+      "comment": "# Clq33x2x3x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        3
+      ],
+      "coeff": "lq3_3233",
+      "comment": "# Clq33x2x3x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        1
+      ],
+      "coeff": "lq3_3311",
+      "comment": "# Clq33x3x1x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        2
+      ],
+      "coeff": "lq3_3312",
+      "comment": "# Clq33x3x1x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        3
+      ],
+      "coeff": "lq3_3313",
+      "comment": "# Clq33x3x1x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        1
+      ],
+      "coeff": "lq3_3321",
+      "comment": "# Clq33x3x2x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        2
+      ],
+      "coeff": "lq3_3322",
+      "comment": "# Clq33x3x2x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        3
+      ],
+      "coeff": "lq3_3323",
+      "comment": "# Clq33x3x2x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        1
+      ],
+      "coeff": "lq3_3331",
+      "comment": "# Clq33x3x3x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        2
+      ],
+      "coeff": "lq3_3332",
+      "comment": "# Clq33x3x3x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        3
+      ],
+      "coeff": "lq3_3333",
+      "comment": "# Clq33x3x3x3 "
+    }
+  ],
+  "frblock38": [
+    {
+      "index": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "coeff": "lu_1111",
+      "comment": "# Clu1x1x1x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        2
+      ],
+      "coeff": "lu_1112",
+      "comment": "# Clu1x1x1x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        3
+      ],
+      "coeff": "lu_1113",
+      "comment": "# Clu1x1x1x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        1
+      ],
+      "coeff": "lu_1121",
+      "comment": "# Clu1x1x2x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "coeff": "lu_1122",
+      "comment": "# Clu1x1x2x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "coeff": "lu_1123",
+      "comment": "# Clu1x1x2x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        1
+      ],
+      "coeff": "lu_1131",
+      "comment": "# Clu1x1x3x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        2
+      ],
+      "coeff": "lu_1132",
+      "comment": "# Clu1x1x3x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        3
+      ],
+      "coeff": "lu_1133",
+      "comment": "# Clu1x1x3x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        1
+      ],
+      "coeff": "lu_1211",
+      "comment": "# Clu1x2x1x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        2
+      ],
+      "coeff": "lu_1212",
+      "comment": "# Clu1x2x1x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        3
+      ],
+      "coeff": "lu_1213",
+      "comment": "# Clu1x2x1x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        1
+      ],
+      "coeff": "lu_1221",
+      "comment": "# Clu1x2x2x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        2
+      ],
+      "coeff": "lu_1222",
+      "comment": "# Clu1x2x2x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        3
+      ],
+      "coeff": "lu_1223",
+      "comment": "# Clu1x2x2x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        1
+      ],
+      "coeff": "lu_1231",
+      "comment": "# Clu1x2x3x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        2
+      ],
+      "coeff": "lu_1232",
+      "comment": "# Clu1x2x3x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        3
+      ],
+      "coeff": "lu_1233",
+      "comment": "# Clu1x2x3x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        1
+      ],
+      "coeff": "lu_1311",
+      "comment": "# Clu1x3x1x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        2
+      ],
+      "coeff": "lu_1312",
+      "comment": "# Clu1x3x1x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        3
+      ],
+      "coeff": "lu_1313",
+      "comment": "# Clu1x3x1x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        1
+      ],
+      "coeff": "lu_1321",
+      "comment": "# Clu1x3x2x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        2
+      ],
+      "coeff": "lu_1322",
+      "comment": "# Clu1x3x2x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        3
+      ],
+      "coeff": "lu_1323",
+      "comment": "# Clu1x3x2x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        1
+      ],
+      "coeff": "lu_1331",
+      "comment": "# Clu1x3x3x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        2
+      ],
+      "coeff": "lu_1332",
+      "comment": "# Clu1x3x3x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        3
+      ],
+      "coeff": "lu_1333",
+      "comment": "# Clu1x3x3x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "coeff": "lu_2111",
+      "comment": "# Clu2x1x1x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        2
+      ],
+      "coeff": "lu_2112",
+      "comment": "# Clu2x1x1x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        3
+      ],
+      "coeff": "lu_2113",
+      "comment": "# Clu2x1x1x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "coeff": "lu_2121",
+      "comment": "# Clu2x1x2x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        2
+      ],
+      "coeff": "lu_2122",
+      "comment": "# Clu2x1x2x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "coeff": "lu_2123",
+      "comment": "# Clu2x1x2x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        1
+      ],
+      "coeff": "lu_2131",
+      "comment": "# Clu2x1x3x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        2
+      ],
+      "coeff": "lu_2132",
+      "comment": "# Clu2x1x3x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        3
+      ],
+      "coeff": "lu_2133",
+      "comment": "# Clu2x1x3x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        1
+      ],
+      "coeff": "lu_2211",
+      "comment": "# Clu2x2x1x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        2
+      ],
+      "coeff": "lu_2212",
+      "comment": "# Clu2x2x1x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        3
+      ],
+      "coeff": "lu_2213",
+      "comment": "# Clu2x2x1x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        1
+      ],
+      "coeff": "lu_2221",
+      "comment": "# Clu2x2x2x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "coeff": "lu_2222",
+      "comment": "# Clu2x2x2x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        3
+      ],
+      "coeff": "lu_2223",
+      "comment": "# Clu2x2x2x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        1
+      ],
+      "coeff": "lu_2231",
+      "comment": "# Clu2x2x3x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        2
+      ],
+      "coeff": "lu_2232",
+      "comment": "# Clu2x2x3x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        3
+      ],
+      "coeff": "lu_2233",
+      "comment": "# Clu2x2x3x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        1
+      ],
+      "coeff": "lu_2311",
+      "comment": "# Clu2x3x1x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        2
+      ],
+      "coeff": "lu_2312",
+      "comment": "# Clu2x3x1x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        3
+      ],
+      "coeff": "lu_2313",
+      "comment": "# Clu2x3x1x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        1
+      ],
+      "coeff": "lu_2321",
+      "comment": "# Clu2x3x2x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        2
+      ],
+      "coeff": "lu_2322",
+      "comment": "# Clu2x3x2x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        3
+      ],
+      "coeff": "lu_2323",
+      "comment": "# Clu2x3x2x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        1
+      ],
+      "coeff": "lu_2331",
+      "comment": "# Clu2x3x3x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        2
+      ],
+      "coeff": "lu_2332",
+      "comment": "# Clu2x3x3x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        3
+      ],
+      "coeff": "lu_2333",
+      "comment": "# Clu2x3x3x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        1
+      ],
+      "coeff": "lu_3111",
+      "comment": "# Clu3x1x1x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        2
+      ],
+      "coeff": "lu_3112",
+      "comment": "# Clu3x1x1x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        3
+      ],
+      "coeff": "lu_3113",
+      "comment": "# Clu3x1x1x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        1
+      ],
+      "coeff": "lu_3121",
+      "comment": "# Clu3x1x2x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        2
+      ],
+      "coeff": "lu_3122",
+      "comment": "# Clu3x1x2x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        3
+      ],
+      "coeff": "lu_3123",
+      "comment": "# Clu3x1x2x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        1
+      ],
+      "coeff": "lu_3131",
+      "comment": "# Clu3x1x3x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        2
+      ],
+      "coeff": "lu_3132",
+      "comment": "# Clu3x1x3x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        3
+      ],
+      "coeff": "lu_3133",
+      "comment": "# Clu3x1x3x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        1
+      ],
+      "coeff": "lu_3211",
+      "comment": "# Clu3x2x1x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        2
+      ],
+      "coeff": "lu_3212",
+      "comment": "# Clu3x2x1x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        3
+      ],
+      "coeff": "lu_3213",
+      "comment": "# Clu3x2x1x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        1
+      ],
+      "coeff": "lu_3221",
+      "comment": "# Clu3x2x2x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        2
+      ],
+      "coeff": "lu_3222",
+      "comment": "# Clu3x2x2x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        3
+      ],
+      "coeff": "lu_3223",
+      "comment": "# Clu3x2x2x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "coeff": "lu_3231",
+      "comment": "# Clu3x2x3x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        2
+      ],
+      "coeff": "lu_3232",
+      "comment": "# Clu3x2x3x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        3
+      ],
+      "coeff": "lu_3233",
+      "comment": "# Clu3x2x3x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        1
+      ],
+      "coeff": "lu_3311",
+      "comment": "# Clu3x3x1x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        2
+      ],
+      "coeff": "lu_3312",
+      "comment": "# Clu3x3x1x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        3
+      ],
+      "coeff": "lu_3313",
+      "comment": "# Clu3x3x1x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        1
+      ],
+      "coeff": "lu_3321",
+      "comment": "# Clu3x3x2x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        2
+      ],
+      "coeff": "lu_3322",
+      "comment": "# Clu3x3x2x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        3
+      ],
+      "coeff": "lu_3323",
+      "comment": "# Clu3x3x2x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        1
+      ],
+      "coeff": "lu_3331",
+      "comment": "# Clu3x3x3x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        2
+      ],
+      "coeff": "lu_3332",
+      "comment": "# Clu3x3x3x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        3
+      ],
+      "coeff": "lu_3333",
+      "comment": "# Clu3x3x3x3 "
+    }
+  ],
+  "frblock39": [
+    {
+      "index": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "coeff": "qd1_1111",
+      "comment": "# Cqd11x1x1x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        2
+      ],
+      "coeff": "qd1_1112",
+      "comment": "# Cqd11x1x1x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        3
+      ],
+      "coeff": "qd1_1113",
+      "comment": "# Cqd11x1x1x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        1
+      ],
+      "coeff": "qd1_1121",
+      "comment": "# Cqd11x1x2x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "coeff": "qd1_1122",
+      "comment": "# Cqd11x1x2x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "coeff": "qd1_1123",
+      "comment": "# Cqd11x1x2x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        1
+      ],
+      "coeff": "qd1_1131",
+      "comment": "# Cqd11x1x3x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        2
+      ],
+      "coeff": "qd1_1132",
+      "comment": "# Cqd11x1x3x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        3
+      ],
+      "coeff": "qd1_1133",
+      "comment": "# Cqd11x1x3x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        1
+      ],
+      "coeff": "qd1_1211",
+      "comment": "# Cqd11x2x1x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        2
+      ],
+      "coeff": "qd1_1212",
+      "comment": "# Cqd11x2x1x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        3
+      ],
+      "coeff": "qd1_1213",
+      "comment": "# Cqd11x2x1x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        1
+      ],
+      "coeff": "qd1_1221",
+      "comment": "# Cqd11x2x2x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        2
+      ],
+      "coeff": "qd1_1222",
+      "comment": "# Cqd11x2x2x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        3
+      ],
+      "coeff": "qd1_1223",
+      "comment": "# Cqd11x2x2x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        1
+      ],
+      "coeff": "qd1_1231",
+      "comment": "# Cqd11x2x3x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        2
+      ],
+      "coeff": "qd1_1232",
+      "comment": "# Cqd11x2x3x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        3
+      ],
+      "coeff": "qd1_1233",
+      "comment": "# Cqd11x2x3x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        1
+      ],
+      "coeff": "qd1_1311",
+      "comment": "# Cqd11x3x1x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        2
+      ],
+      "coeff": "qd1_1312",
+      "comment": "# Cqd11x3x1x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        3
+      ],
+      "coeff": "qd1_1313",
+      "comment": "# Cqd11x3x1x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        1
+      ],
+      "coeff": "qd1_1321",
+      "comment": "# Cqd11x3x2x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        2
+      ],
+      "coeff": "qd1_1322",
+      "comment": "# Cqd11x3x2x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        3
+      ],
+      "coeff": "qd1_1323",
+      "comment": "# Cqd11x3x2x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        1
+      ],
+      "coeff": "qd1_1331",
+      "comment": "# Cqd11x3x3x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        2
+      ],
+      "coeff": "qd1_1332",
+      "comment": "# Cqd11x3x3x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        3
+      ],
+      "coeff": "qd1_1333",
+      "comment": "# Cqd11x3x3x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "coeff": "qd1_2111",
+      "comment": "# Cqd12x1x1x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        2
+      ],
+      "coeff": "qd1_2112",
+      "comment": "# Cqd12x1x1x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        3
+      ],
+      "coeff": "qd1_2113",
+      "comment": "# Cqd12x1x1x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "coeff": "qd1_2121",
+      "comment": "# Cqd12x1x2x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        2
+      ],
+      "coeff": "qd1_2122",
+      "comment": "# Cqd12x1x2x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "coeff": "qd1_2123",
+      "comment": "# Cqd12x1x2x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        1
+      ],
+      "coeff": "qd1_2131",
+      "comment": "# Cqd12x1x3x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        2
+      ],
+      "coeff": "qd1_2132",
+      "comment": "# Cqd12x1x3x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        3
+      ],
+      "coeff": "qd1_2133",
+      "comment": "# Cqd12x1x3x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        1
+      ],
+      "coeff": "qd1_2211",
+      "comment": "# Cqd12x2x1x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        2
+      ],
+      "coeff": "qd1_2212",
+      "comment": "# Cqd12x2x1x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        3
+      ],
+      "coeff": "qd1_2213",
+      "comment": "# Cqd12x2x1x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        1
+      ],
+      "coeff": "qd1_2221",
+      "comment": "# Cqd12x2x2x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "coeff": "qd1_2222",
+      "comment": "# Cqd12x2x2x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        3
+      ],
+      "coeff": "qd1_2223",
+      "comment": "# Cqd12x2x2x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        1
+      ],
+      "coeff": "qd1_2231",
+      "comment": "# Cqd12x2x3x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        2
+      ],
+      "coeff": "qd1_2232",
+      "comment": "# Cqd12x2x3x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        3
+      ],
+      "coeff": "qd1_2233",
+      "comment": "# Cqd12x2x3x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        1
+      ],
+      "coeff": "qd1_2311",
+      "comment": "# Cqd12x3x1x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        2
+      ],
+      "coeff": "qd1_2312",
+      "comment": "# Cqd12x3x1x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        3
+      ],
+      "coeff": "qd1_2313",
+      "comment": "# Cqd12x3x1x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        1
+      ],
+      "coeff": "qd1_2321",
+      "comment": "# Cqd12x3x2x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        2
+      ],
+      "coeff": "qd1_2322",
+      "comment": "# Cqd12x3x2x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        3
+      ],
+      "coeff": "qd1_2323",
+      "comment": "# Cqd12x3x2x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        1
+      ],
+      "coeff": "qd1_2331",
+      "comment": "# Cqd12x3x3x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        2
+      ],
+      "coeff": "qd1_2332",
+      "comment": "# Cqd12x3x3x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        3
+      ],
+      "coeff": "qd1_2333",
+      "comment": "# Cqd12x3x3x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        1
+      ],
+      "coeff": "qd1_3111",
+      "comment": "# Cqd13x1x1x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        2
+      ],
+      "coeff": "qd1_3112",
+      "comment": "# Cqd13x1x1x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        3
+      ],
+      "coeff": "qd1_3113",
+      "comment": "# Cqd13x1x1x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        1
+      ],
+      "coeff": "qd1_3121",
+      "comment": "# Cqd13x1x2x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        2
+      ],
+      "coeff": "qd1_3122",
+      "comment": "# Cqd13x1x2x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        3
+      ],
+      "coeff": "qd1_3123",
+      "comment": "# Cqd13x1x2x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        1
+      ],
+      "coeff": "qd1_3131",
+      "comment": "# Cqd13x1x3x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        2
+      ],
+      "coeff": "qd1_3132",
+      "comment": "# Cqd13x1x3x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        3
+      ],
+      "coeff": "qd1_3133",
+      "comment": "# Cqd13x1x3x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        1
+      ],
+      "coeff": "qd1_3211",
+      "comment": "# Cqd13x2x1x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        2
+      ],
+      "coeff": "qd1_3212",
+      "comment": "# Cqd13x2x1x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        3
+      ],
+      "coeff": "qd1_3213",
+      "comment": "# Cqd13x2x1x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        1
+      ],
+      "coeff": "qd1_3221",
+      "comment": "# Cqd13x2x2x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        2
+      ],
+      "coeff": "qd1_3222",
+      "comment": "# Cqd13x2x2x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        3
+      ],
+      "coeff": "qd1_3223",
+      "comment": "# Cqd13x2x2x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "coeff": "qd1_3231",
+      "comment": "# Cqd13x2x3x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        2
+      ],
+      "coeff": "qd1_3232",
+      "comment": "# Cqd13x2x3x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        3
+      ],
+      "coeff": "qd1_3233",
+      "comment": "# Cqd13x2x3x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        1
+      ],
+      "coeff": "qd1_3311",
+      "comment": "# Cqd13x3x1x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        2
+      ],
+      "coeff": "qd1_3312",
+      "comment": "# Cqd13x3x1x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        3
+      ],
+      "coeff": "qd1_3313",
+      "comment": "# Cqd13x3x1x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        1
+      ],
+      "coeff": "qd1_3321",
+      "comment": "# Cqd13x3x2x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        2
+      ],
+      "coeff": "qd1_3322",
+      "comment": "# Cqd13x3x2x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        3
+      ],
+      "coeff": "qd1_3323",
+      "comment": "# Cqd13x3x2x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        1
+      ],
+      "coeff": "qd1_3331",
+      "comment": "# Cqd13x3x3x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        2
+      ],
+      "coeff": "qd1_3332",
+      "comment": "# Cqd13x3x3x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        3
+      ],
+      "coeff": "qd1_3333",
+      "comment": "# Cqd13x3x3x3 "
+    }
+  ],
+  "frblock4": [
+    {
+      "index": [
+        1,
+        1
+      ],
+      "coeff": "dB_11",
+      "comment": "# CdB1x1 "
+    },
+    {
+      "index": [
+        1,
+        2
+      ],
+      "coeff": "dB_12",
+      "comment": "# CdB1x2 "
+    },
+    {
+      "index": [
+        1,
+        3
+      ],
+      "coeff": "dB_13",
+      "comment": "# CdB1x3 "
+    },
+    {
+      "index": [
+        2,
+        1
+      ],
+      "coeff": "dB_21",
+      "comment": "# CdB2x1 "
+    },
+    {
+      "index": [
+        2,
+        2
+      ],
+      "coeff": "dB_22",
+      "comment": "# CdB2x2 "
+    },
+    {
+      "index": [
+        2,
+        3
+      ],
+      "coeff": "dB_23",
+      "comment": "# CdB2x3 "
+    },
+    {
+      "index": [
+        3,
+        1
+      ],
+      "coeff": "dB_31",
+      "comment": "# CdB3x1 "
+    },
+    {
+      "index": [
+        3,
+        2
+      ],
+      "coeff": "dB_32",
+      "comment": "# CdB3x2 "
+    },
+    {
+      "index": [
+        3,
+        3
+      ],
+      "coeff": "dB_33",
+      "comment": "# CdB3x3 "
+    }
+  ],
+  "frblock40": [
+    {
+      "index": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "coeff": "qd8_1111",
+      "comment": "# Cqd81x1x1x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        2
+      ],
+      "coeff": "qd8_1112",
+      "comment": "# Cqd81x1x1x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        3
+      ],
+      "coeff": "qd8_1113",
+      "comment": "# Cqd81x1x1x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        1
+      ],
+      "coeff": "qd8_1121",
+      "comment": "# Cqd81x1x2x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "coeff": "qd8_1122",
+      "comment": "# Cqd81x1x2x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "coeff": "qd8_1123",
+      "comment": "# Cqd81x1x2x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        1
+      ],
+      "coeff": "qd8_1131",
+      "comment": "# Cqd81x1x3x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        2
+      ],
+      "coeff": "qd8_1132",
+      "comment": "# Cqd81x1x3x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        3
+      ],
+      "coeff": "qd8_1133",
+      "comment": "# Cqd81x1x3x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        1
+      ],
+      "coeff": "qd8_1211",
+      "comment": "# Cqd81x2x1x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        2
+      ],
+      "coeff": "qd8_1212",
+      "comment": "# Cqd81x2x1x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        3
+      ],
+      "coeff": "qd8_1213",
+      "comment": "# Cqd81x2x1x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        1
+      ],
+      "coeff": "qd8_1221",
+      "comment": "# Cqd81x2x2x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        2
+      ],
+      "coeff": "qd8_1222",
+      "comment": "# Cqd81x2x2x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        3
+      ],
+      "coeff": "qd8_1223",
+      "comment": "# Cqd81x2x2x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        1
+      ],
+      "coeff": "qd8_1231",
+      "comment": "# Cqd81x2x3x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        2
+      ],
+      "coeff": "qd8_1232",
+      "comment": "# Cqd81x2x3x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        3
+      ],
+      "coeff": "qd8_1233",
+      "comment": "# Cqd81x2x3x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        1
+      ],
+      "coeff": "qd8_1311",
+      "comment": "# Cqd81x3x1x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        2
+      ],
+      "coeff": "qd8_1312",
+      "comment": "# Cqd81x3x1x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        3
+      ],
+      "coeff": "qd8_1313",
+      "comment": "# Cqd81x3x1x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        1
+      ],
+      "coeff": "qd8_1321",
+      "comment": "# Cqd81x3x2x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        2
+      ],
+      "coeff": "qd8_1322",
+      "comment": "# Cqd81x3x2x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        3
+      ],
+      "coeff": "qd8_1323",
+      "comment": "# Cqd81x3x2x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        1
+      ],
+      "coeff": "qd8_1331",
+      "comment": "# Cqd81x3x3x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        2
+      ],
+      "coeff": "qd8_1332",
+      "comment": "# Cqd81x3x3x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        3
+      ],
+      "coeff": "qd8_1333",
+      "comment": "# Cqd81x3x3x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "coeff": "qd8_2111",
+      "comment": "# Cqd82x1x1x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        2
+      ],
+      "coeff": "qd8_2112",
+      "comment": "# Cqd82x1x1x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        3
+      ],
+      "coeff": "qd8_2113",
+      "comment": "# Cqd82x1x1x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "coeff": "qd8_2121",
+      "comment": "# Cqd82x1x2x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        2
+      ],
+      "coeff": "qd8_2122",
+      "comment": "# Cqd82x1x2x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "coeff": "qd8_2123",
+      "comment": "# Cqd82x1x2x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        1
+      ],
+      "coeff": "qd8_2131",
+      "comment": "# Cqd82x1x3x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        2
+      ],
+      "coeff": "qd8_2132",
+      "comment": "# Cqd82x1x3x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        3
+      ],
+      "coeff": "qd8_2133",
+      "comment": "# Cqd82x1x3x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        1
+      ],
+      "coeff": "qd8_2211",
+      "comment": "# Cqd82x2x1x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        2
+      ],
+      "coeff": "qd8_2212",
+      "comment": "# Cqd82x2x1x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        3
+      ],
+      "coeff": "qd8_2213",
+      "comment": "# Cqd82x2x1x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        1
+      ],
+      "coeff": "qd8_2221",
+      "comment": "# Cqd82x2x2x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "coeff": "qd8_2222",
+      "comment": "# Cqd82x2x2x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        3
+      ],
+      "coeff": "qd8_2223",
+      "comment": "# Cqd82x2x2x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        1
+      ],
+      "coeff": "qd8_2231",
+      "comment": "# Cqd82x2x3x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        2
+      ],
+      "coeff": "qd8_2232",
+      "comment": "# Cqd82x2x3x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        3
+      ],
+      "coeff": "qd8_2233",
+      "comment": "# Cqd82x2x3x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        1
+      ],
+      "coeff": "qd8_2311",
+      "comment": "# Cqd82x3x1x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        2
+      ],
+      "coeff": "qd8_2312",
+      "comment": "# Cqd82x3x1x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        3
+      ],
+      "coeff": "qd8_2313",
+      "comment": "# Cqd82x3x1x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        1
+      ],
+      "coeff": "qd8_2321",
+      "comment": "# Cqd82x3x2x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        2
+      ],
+      "coeff": "qd8_2322",
+      "comment": "# Cqd82x3x2x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        3
+      ],
+      "coeff": "qd8_2323",
+      "comment": "# Cqd82x3x2x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        1
+      ],
+      "coeff": "qd8_2331",
+      "comment": "# Cqd82x3x3x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        2
+      ],
+      "coeff": "qd8_2332",
+      "comment": "# Cqd82x3x3x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        3
+      ],
+      "coeff": "qd8_2333",
+      "comment": "# Cqd82x3x3x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        1
+      ],
+      "coeff": "qd8_3111",
+      "comment": "# Cqd83x1x1x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        2
+      ],
+      "coeff": "qd8_3112",
+      "comment": "# Cqd83x1x1x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        3
+      ],
+      "coeff": "qd8_3113",
+      "comment": "# Cqd83x1x1x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        1
+      ],
+      "coeff": "qd8_3121",
+      "comment": "# Cqd83x1x2x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        2
+      ],
+      "coeff": "qd8_3122",
+      "comment": "# Cqd83x1x2x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        3
+      ],
+      "coeff": "qd8_3123",
+      "comment": "# Cqd83x1x2x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        1
+      ],
+      "coeff": "qd8_3131",
+      "comment": "# Cqd83x1x3x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        2
+      ],
+      "coeff": "qd8_3132",
+      "comment": "# Cqd83x1x3x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        3
+      ],
+      "coeff": "qd8_3133",
+      "comment": "# Cqd83x1x3x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        1
+      ],
+      "coeff": "qd8_3211",
+      "comment": "# Cqd83x2x1x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        2
+      ],
+      "coeff": "qd8_3212",
+      "comment": "# Cqd83x2x1x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        3
+      ],
+      "coeff": "qd8_3213",
+      "comment": "# Cqd83x2x1x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        1
+      ],
+      "coeff": "qd8_3221",
+      "comment": "# Cqd83x2x2x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        2
+      ],
+      "coeff": "qd8_3222",
+      "comment": "# Cqd83x2x2x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        3
+      ],
+      "coeff": "qd8_3223",
+      "comment": "# Cqd83x2x2x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "coeff": "qd8_3231",
+      "comment": "# Cqd83x2x3x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        2
+      ],
+      "coeff": "qd8_3232",
+      "comment": "# Cqd83x2x3x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        3
+      ],
+      "coeff": "qd8_3233",
+      "comment": "# Cqd83x2x3x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        1
+      ],
+      "coeff": "qd8_3311",
+      "comment": "# Cqd83x3x1x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        2
+      ],
+      "coeff": "qd8_3312",
+      "comment": "# Cqd83x3x1x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        3
+      ],
+      "coeff": "qd8_3313",
+      "comment": "# Cqd83x3x1x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        1
+      ],
+      "coeff": "qd8_3321",
+      "comment": "# Cqd83x3x2x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        2
+      ],
+      "coeff": "qd8_3322",
+      "comment": "# Cqd83x3x2x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        3
+      ],
+      "coeff": "qd8_3323",
+      "comment": "# Cqd83x3x2x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        1
+      ],
+      "coeff": "qd8_3331",
+      "comment": "# Cqd83x3x3x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        2
+      ],
+      "coeff": "qd8_3332",
+      "comment": "# Cqd83x3x3x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        3
+      ],
+      "coeff": "qd8_3333",
+      "comment": "# Cqd83x3x3x3 "
+    }
+  ],
+  "frblock41": [
+    {
+      "index": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "coeff": "qe_1111",
+      "comment": "# Cqe1x1x1x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        2
+      ],
+      "coeff": "qe_1112",
+      "comment": "# Cqe1x1x1x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        3
+      ],
+      "coeff": "qe_1113",
+      "comment": "# Cqe1x1x1x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        1
+      ],
+      "coeff": "qe_1121",
+      "comment": "# Cqe1x1x2x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "coeff": "qe_1122",
+      "comment": "# Cqe1x1x2x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "coeff": "qe_1123",
+      "comment": "# Cqe1x1x2x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        1
+      ],
+      "coeff": "qe_1131",
+      "comment": "# Cqe1x1x3x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        2
+      ],
+      "coeff": "qe_1132",
+      "comment": "# Cqe1x1x3x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        3
+      ],
+      "coeff": "qe_1133",
+      "comment": "# Cqe1x1x3x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        1
+      ],
+      "coeff": "qe_1211",
+      "comment": "# Cqe1x2x1x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        2
+      ],
+      "coeff": "qe_1212",
+      "comment": "# Cqe1x2x1x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        3
+      ],
+      "coeff": "qe_1213",
+      "comment": "# Cqe1x2x1x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        1
+      ],
+      "coeff": "qe_1221",
+      "comment": "# Cqe1x2x2x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        2
+      ],
+      "coeff": "qe_1222",
+      "comment": "# Cqe1x2x2x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        3
+      ],
+      "coeff": "qe_1223",
+      "comment": "# Cqe1x2x2x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        1
+      ],
+      "coeff": "qe_1231",
+      "comment": "# Cqe1x2x3x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        2
+      ],
+      "coeff": "qe_1232",
+      "comment": "# Cqe1x2x3x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        3
+      ],
+      "coeff": "qe_1233",
+      "comment": "# Cqe1x2x3x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        1
+      ],
+      "coeff": "qe_1311",
+      "comment": "# Cqe1x3x1x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        2
+      ],
+      "coeff": "qe_1312",
+      "comment": "# Cqe1x3x1x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        3
+      ],
+      "coeff": "qe_1313",
+      "comment": "# Cqe1x3x1x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        1
+      ],
+      "coeff": "qe_1321",
+      "comment": "# Cqe1x3x2x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        2
+      ],
+      "coeff": "qe_1322",
+      "comment": "# Cqe1x3x2x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        3
+      ],
+      "coeff": "qe_1323",
+      "comment": "# Cqe1x3x2x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        1
+      ],
+      "coeff": "qe_1331",
+      "comment": "# Cqe1x3x3x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        2
+      ],
+      "coeff": "qe_1332",
+      "comment": "# Cqe1x3x3x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        3
+      ],
+      "coeff": "qe_1333",
+      "comment": "# Cqe1x3x3x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "coeff": "qe_2111",
+      "comment": "# Cqe2x1x1x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        2
+      ],
+      "coeff": "qe_2112",
+      "comment": "# Cqe2x1x1x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        3
+      ],
+      "coeff": "qe_2113",
+      "comment": "# Cqe2x1x1x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "coeff": "qe_2121",
+      "comment": "# Cqe2x1x2x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        2
+      ],
+      "coeff": "qe_2122",
+      "comment": "# Cqe2x1x2x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "coeff": "qe_2123",
+      "comment": "# Cqe2x1x2x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        1
+      ],
+      "coeff": "qe_2131",
+      "comment": "# Cqe2x1x3x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        2
+      ],
+      "coeff": "qe_2132",
+      "comment": "# Cqe2x1x3x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        3
+      ],
+      "coeff": "qe_2133",
+      "comment": "# Cqe2x1x3x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        1
+      ],
+      "coeff": "qe_2211",
+      "comment": "# Cqe2x2x1x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        2
+      ],
+      "coeff": "qe_2212",
+      "comment": "# Cqe2x2x1x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        3
+      ],
+      "coeff": "qe_2213",
+      "comment": "# Cqe2x2x1x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        1
+      ],
+      "coeff": "qe_2221",
+      "comment": "# Cqe2x2x2x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "coeff": "qe_2222",
+      "comment": "# Cqe2x2x2x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        3
+      ],
+      "coeff": "qe_2223",
+      "comment": "# Cqe2x2x2x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        1
+      ],
+      "coeff": "qe_2231",
+      "comment": "# Cqe2x2x3x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        2
+      ],
+      "coeff": "qe_2232",
+      "comment": "# Cqe2x2x3x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        3
+      ],
+      "coeff": "qe_2233",
+      "comment": "# Cqe2x2x3x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        1
+      ],
+      "coeff": "qe_2311",
+      "comment": "# Cqe2x3x1x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        2
+      ],
+      "coeff": "qe_2312",
+      "comment": "# Cqe2x3x1x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        3
+      ],
+      "coeff": "qe_2313",
+      "comment": "# Cqe2x3x1x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        1
+      ],
+      "coeff": "qe_2321",
+      "comment": "# Cqe2x3x2x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        2
+      ],
+      "coeff": "qe_2322",
+      "comment": "# Cqe2x3x2x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        3
+      ],
+      "coeff": "qe_2323",
+      "comment": "# Cqe2x3x2x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        1
+      ],
+      "coeff": "qe_2331",
+      "comment": "# Cqe2x3x3x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        2
+      ],
+      "coeff": "qe_2332",
+      "comment": "# Cqe2x3x3x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        3
+      ],
+      "coeff": "qe_2333",
+      "comment": "# Cqe2x3x3x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        1
+      ],
+      "coeff": "qe_3111",
+      "comment": "# Cqe3x1x1x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        2
+      ],
+      "coeff": "qe_3112",
+      "comment": "# Cqe3x1x1x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        3
+      ],
+      "coeff": "qe_3113",
+      "comment": "# Cqe3x1x1x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        1
+      ],
+      "coeff": "qe_3121",
+      "comment": "# Cqe3x1x2x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        2
+      ],
+      "coeff": "qe_3122",
+      "comment": "# Cqe3x1x2x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        3
+      ],
+      "coeff": "qe_3123",
+      "comment": "# Cqe3x1x2x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        1
+      ],
+      "coeff": "qe_3131",
+      "comment": "# Cqe3x1x3x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        2
+      ],
+      "coeff": "qe_3132",
+      "comment": "# Cqe3x1x3x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        3
+      ],
+      "coeff": "qe_3133",
+      "comment": "# Cqe3x1x3x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        1
+      ],
+      "coeff": "qe_3211",
+      "comment": "# Cqe3x2x1x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        2
+      ],
+      "coeff": "qe_3212",
+      "comment": "# Cqe3x2x1x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        3
+      ],
+      "coeff": "qe_3213",
+      "comment": "# Cqe3x2x1x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        1
+      ],
+      "coeff": "qe_3221",
+      "comment": "# Cqe3x2x2x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        2
+      ],
+      "coeff": "qe_3222",
+      "comment": "# Cqe3x2x2x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        3
+      ],
+      "coeff": "qe_3223",
+      "comment": "# Cqe3x2x2x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "coeff": "qe_3231",
+      "comment": "# Cqe3x2x3x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        2
+      ],
+      "coeff": "qe_3232",
+      "comment": "# Cqe3x2x3x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        3
+      ],
+      "coeff": "qe_3233",
+      "comment": "# Cqe3x2x3x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        1
+      ],
+      "coeff": "qe_3311",
+      "comment": "# Cqe3x3x1x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        2
+      ],
+      "coeff": "qe_3312",
+      "comment": "# Cqe3x3x1x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        3
+      ],
+      "coeff": "qe_3313",
+      "comment": "# Cqe3x3x1x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        1
+      ],
+      "coeff": "qe_3321",
+      "comment": "# Cqe3x3x2x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        2
+      ],
+      "coeff": "qe_3322",
+      "comment": "# Cqe3x3x2x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        3
+      ],
+      "coeff": "qe_3323",
+      "comment": "# Cqe3x3x2x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        1
+      ],
+      "coeff": "qe_3331",
+      "comment": "# Cqe3x3x3x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        2
+      ],
+      "coeff": "qe_3332",
+      "comment": "# Cqe3x3x3x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        3
+      ],
+      "coeff": "qe_3333",
+      "comment": "# Cqe3x3x3x3 "
+    }
+  ],
+  "frblock42": [
+    {
+      "index": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "coeff": "qq1_1111",
+      "comment": "# Cqq11x1x1x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        2
+      ],
+      "coeff": "qq1_1112",
+      "comment": "# Cqq11x1x1x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        3
+      ],
+      "coeff": "qq1_1113",
+      "comment": "# Cqq11x1x1x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        1
+      ],
+      "coeff": "qq1_1121",
+      "comment": "# Cqq11x1x2x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "coeff": "qq1_1122",
+      "comment": "# Cqq11x1x2x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "coeff": "qq1_1123",
+      "comment": "# Cqq11x1x2x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        1
+      ],
+      "coeff": "qq1_1131",
+      "comment": "# Cqq11x1x3x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        2
+      ],
+      "coeff": "qq1_1132",
+      "comment": "# Cqq11x1x3x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        3
+      ],
+      "coeff": "qq1_1133",
+      "comment": "# Cqq11x1x3x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        1
+      ],
+      "coeff": "qq1_1211",
+      "comment": "# Cqq11x2x1x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        2
+      ],
+      "coeff": "qq1_1212",
+      "comment": "# Cqq11x2x1x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        3
+      ],
+      "coeff": "qq1_1213",
+      "comment": "# Cqq11x2x1x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        1
+      ],
+      "coeff": "qq1_1221",
+      "comment": "# Cqq11x2x2x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        2
+      ],
+      "coeff": "qq1_1222",
+      "comment": "# Cqq11x2x2x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        3
+      ],
+      "coeff": "qq1_1223",
+      "comment": "# Cqq11x2x2x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        1
+      ],
+      "coeff": "qq1_1231",
+      "comment": "# Cqq11x2x3x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        2
+      ],
+      "coeff": "qq1_1232",
+      "comment": "# Cqq11x2x3x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        3
+      ],
+      "coeff": "qq1_1233",
+      "comment": "# Cqq11x2x3x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        1
+      ],
+      "coeff": "qq1_1311",
+      "comment": "# Cqq11x3x1x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        2
+      ],
+      "coeff": "qq1_1312",
+      "comment": "# Cqq11x3x1x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        3
+      ],
+      "coeff": "qq1_1313",
+      "comment": "# Cqq11x3x1x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        1
+      ],
+      "coeff": "qq1_1321",
+      "comment": "# Cqq11x3x2x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        2
+      ],
+      "coeff": "qq1_1322",
+      "comment": "# Cqq11x3x2x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        3
+      ],
+      "coeff": "qq1_1323",
+      "comment": "# Cqq11x3x2x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        1
+      ],
+      "coeff": "qq1_1331",
+      "comment": "# Cqq11x3x3x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        2
+      ],
+      "coeff": "qq1_1332",
+      "comment": "# Cqq11x3x3x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        3
+      ],
+      "coeff": "qq1_1333",
+      "comment": "# Cqq11x3x3x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "coeff": "qq1_2111",
+      "comment": "# Cqq12x1x1x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        2
+      ],
+      "coeff": "qq1_2112",
+      "comment": "# Cqq12x1x1x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        3
+      ],
+      "coeff": "qq1_2113",
+      "comment": "# Cqq12x1x1x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "coeff": "qq1_2121",
+      "comment": "# Cqq12x1x2x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        2
+      ],
+      "coeff": "qq1_2122",
+      "comment": "# Cqq12x1x2x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "coeff": "qq1_2123",
+      "comment": "# Cqq12x1x2x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        1
+      ],
+      "coeff": "qq1_2131",
+      "comment": "# Cqq12x1x3x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        2
+      ],
+      "coeff": "qq1_2132",
+      "comment": "# Cqq12x1x3x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        3
+      ],
+      "coeff": "qq1_2133",
+      "comment": "# Cqq12x1x3x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        1
+      ],
+      "coeff": "qq1_2211",
+      "comment": "# Cqq12x2x1x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        2
+      ],
+      "coeff": "qq1_2212",
+      "comment": "# Cqq12x2x1x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        3
+      ],
+      "coeff": "qq1_2213",
+      "comment": "# Cqq12x2x1x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        1
+      ],
+      "coeff": "qq1_2221",
+      "comment": "# Cqq12x2x2x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "coeff": "qq1_2222",
+      "comment": "# Cqq12x2x2x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        3
+      ],
+      "coeff": "qq1_2223",
+      "comment": "# Cqq12x2x2x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        1
+      ],
+      "coeff": "qq1_2231",
+      "comment": "# Cqq12x2x3x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        2
+      ],
+      "coeff": "qq1_2232",
+      "comment": "# Cqq12x2x3x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        3
+      ],
+      "coeff": "qq1_2233",
+      "comment": "# Cqq12x2x3x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        1
+      ],
+      "coeff": "qq1_2311",
+      "comment": "# Cqq12x3x1x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        2
+      ],
+      "coeff": "qq1_2312",
+      "comment": "# Cqq12x3x1x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        3
+      ],
+      "coeff": "qq1_2313",
+      "comment": "# Cqq12x3x1x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        1
+      ],
+      "coeff": "qq1_2321",
+      "comment": "# Cqq12x3x2x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        2
+      ],
+      "coeff": "qq1_2322",
+      "comment": "# Cqq12x3x2x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        3
+      ],
+      "coeff": "qq1_2323",
+      "comment": "# Cqq12x3x2x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        1
+      ],
+      "coeff": "qq1_2331",
+      "comment": "# Cqq12x3x3x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        2
+      ],
+      "coeff": "qq1_2332",
+      "comment": "# Cqq12x3x3x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        3
+      ],
+      "coeff": "qq1_2333",
+      "comment": "# Cqq12x3x3x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        1
+      ],
+      "coeff": "qq1_3111",
+      "comment": "# Cqq13x1x1x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        2
+      ],
+      "coeff": "qq1_3112",
+      "comment": "# Cqq13x1x1x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        3
+      ],
+      "coeff": "qq1_3113",
+      "comment": "# Cqq13x1x1x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        1
+      ],
+      "coeff": "qq1_3121",
+      "comment": "# Cqq13x1x2x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        2
+      ],
+      "coeff": "qq1_3122",
+      "comment": "# Cqq13x1x2x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        3
+      ],
+      "coeff": "qq1_3123",
+      "comment": "# Cqq13x1x2x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        1
+      ],
+      "coeff": "qq1_3131",
+      "comment": "# Cqq13x1x3x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        2
+      ],
+      "coeff": "qq1_3132",
+      "comment": "# Cqq13x1x3x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        3
+      ],
+      "coeff": "qq1_3133",
+      "comment": "# Cqq13x1x3x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        1
+      ],
+      "coeff": "qq1_3211",
+      "comment": "# Cqq13x2x1x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        2
+      ],
+      "coeff": "qq1_3212",
+      "comment": "# Cqq13x2x1x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        3
+      ],
+      "coeff": "qq1_3213",
+      "comment": "# Cqq13x2x1x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        1
+      ],
+      "coeff": "qq1_3221",
+      "comment": "# Cqq13x2x2x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        2
+      ],
+      "coeff": "qq1_3222",
+      "comment": "# Cqq13x2x2x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        3
+      ],
+      "coeff": "qq1_3223",
+      "comment": "# Cqq13x2x2x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "coeff": "qq1_3231",
+      "comment": "# Cqq13x2x3x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        2
+      ],
+      "coeff": "qq1_3232",
+      "comment": "# Cqq13x2x3x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        3
+      ],
+      "coeff": "qq1_3233",
+      "comment": "# Cqq13x2x3x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        1
+      ],
+      "coeff": "qq1_3311",
+      "comment": "# Cqq13x3x1x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        2
+      ],
+      "coeff": "qq1_3312",
+      "comment": "# Cqq13x3x1x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        3
+      ],
+      "coeff": "qq1_3313",
+      "comment": "# Cqq13x3x1x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        1
+      ],
+      "coeff": "qq1_3321",
+      "comment": "# Cqq13x3x2x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        2
+      ],
+      "coeff": "qq1_3322",
+      "comment": "# Cqq13x3x2x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        3
+      ],
+      "coeff": "qq1_3323",
+      "comment": "# Cqq13x3x2x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        1
+      ],
+      "coeff": "qq1_3331",
+      "comment": "# Cqq13x3x3x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        2
+      ],
+      "coeff": "qq1_3332",
+      "comment": "# Cqq13x3x3x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        3
+      ],
+      "coeff": "qq1_3333",
+      "comment": "# Cqq13x3x3x3 "
+    }
+  ],
+  "frblock43": [
+    {
+      "index": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "coeff": "qq3_1111",
+      "comment": "# Cqq31x1x1x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        2
+      ],
+      "coeff": "qq3_1112",
+      "comment": "# Cqq31x1x1x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        3
+      ],
+      "coeff": "qq3_1113",
+      "comment": "# Cqq31x1x1x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        1
+      ],
+      "coeff": "qq3_1121",
+      "comment": "# Cqq31x1x2x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "coeff": "qq3_1122",
+      "comment": "# Cqq31x1x2x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "coeff": "qq3_1123",
+      "comment": "# Cqq31x1x2x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        1
+      ],
+      "coeff": "qq3_1131",
+      "comment": "# Cqq31x1x3x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        2
+      ],
+      "coeff": "qq3_1132",
+      "comment": "# Cqq31x1x3x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        3
+      ],
+      "coeff": "qq3_1133",
+      "comment": "# Cqq31x1x3x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        1
+      ],
+      "coeff": "qq3_1211",
+      "comment": "# Cqq31x2x1x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        2
+      ],
+      "coeff": "qq3_1212",
+      "comment": "# Cqq31x2x1x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        3
+      ],
+      "coeff": "qq3_1213",
+      "comment": "# Cqq31x2x1x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        1
+      ],
+      "coeff": "qq3_1221",
+      "comment": "# Cqq31x2x2x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        2
+      ],
+      "coeff": "qq3_1222",
+      "comment": "# Cqq31x2x2x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        3
+      ],
+      "coeff": "qq3_1223",
+      "comment": "# Cqq31x2x2x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        1
+      ],
+      "coeff": "qq3_1231",
+      "comment": "# Cqq31x2x3x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        2
+      ],
+      "coeff": "qq3_1232",
+      "comment": "# Cqq31x2x3x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        3
+      ],
+      "coeff": "qq3_1233",
+      "comment": "# Cqq31x2x3x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        1
+      ],
+      "coeff": "qq3_1311",
+      "comment": "# Cqq31x3x1x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        2
+      ],
+      "coeff": "qq3_1312",
+      "comment": "# Cqq31x3x1x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        3
+      ],
+      "coeff": "qq3_1313",
+      "comment": "# Cqq31x3x1x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        1
+      ],
+      "coeff": "qq3_1321",
+      "comment": "# Cqq31x3x2x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        2
+      ],
+      "coeff": "qq3_1322",
+      "comment": "# Cqq31x3x2x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        3
+      ],
+      "coeff": "qq3_1323",
+      "comment": "# Cqq31x3x2x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        1
+      ],
+      "coeff": "qq3_1331",
+      "comment": "# Cqq31x3x3x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        2
+      ],
+      "coeff": "qq3_1332",
+      "comment": "# Cqq31x3x3x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        3
+      ],
+      "coeff": "qq3_1333",
+      "comment": "# Cqq31x3x3x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "coeff": "qq3_2111",
+      "comment": "# Cqq32x1x1x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        2
+      ],
+      "coeff": "qq3_2112",
+      "comment": "# Cqq32x1x1x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        3
+      ],
+      "coeff": "qq3_2113",
+      "comment": "# Cqq32x1x1x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "coeff": "qq3_2121",
+      "comment": "# Cqq32x1x2x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        2
+      ],
+      "coeff": "qq3_2122",
+      "comment": "# Cqq32x1x2x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "coeff": "qq3_2123",
+      "comment": "# Cqq32x1x2x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        1
+      ],
+      "coeff": "qq3_2131",
+      "comment": "# Cqq32x1x3x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        2
+      ],
+      "coeff": "qq3_2132",
+      "comment": "# Cqq32x1x3x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        3
+      ],
+      "coeff": "qq3_2133",
+      "comment": "# Cqq32x1x3x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        1
+      ],
+      "coeff": "qq3_2211",
+      "comment": "# Cqq32x2x1x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        2
+      ],
+      "coeff": "qq3_2212",
+      "comment": "# Cqq32x2x1x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        3
+      ],
+      "coeff": "qq3_2213",
+      "comment": "# Cqq32x2x1x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        1
+      ],
+      "coeff": "qq3_2221",
+      "comment": "# Cqq32x2x2x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "coeff": "qq3_2222",
+      "comment": "# Cqq32x2x2x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        3
+      ],
+      "coeff": "qq3_2223",
+      "comment": "# Cqq32x2x2x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        1
+      ],
+      "coeff": "qq3_2231",
+      "comment": "# Cqq32x2x3x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        2
+      ],
+      "coeff": "qq3_2232",
+      "comment": "# Cqq32x2x3x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        3
+      ],
+      "coeff": "qq3_2233",
+      "comment": "# Cqq32x2x3x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        1
+      ],
+      "coeff": "qq3_2311",
+      "comment": "# Cqq32x3x1x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        2
+      ],
+      "coeff": "qq3_2312",
+      "comment": "# Cqq32x3x1x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        3
+      ],
+      "coeff": "qq3_2313",
+      "comment": "# Cqq32x3x1x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        1
+      ],
+      "coeff": "qq3_2321",
+      "comment": "# Cqq32x3x2x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        2
+      ],
+      "coeff": "qq3_2322",
+      "comment": "# Cqq32x3x2x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        3
+      ],
+      "coeff": "qq3_2323",
+      "comment": "# Cqq32x3x2x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        1
+      ],
+      "coeff": "qq3_2331",
+      "comment": "# Cqq32x3x3x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        2
+      ],
+      "coeff": "qq3_2332",
+      "comment": "# Cqq32x3x3x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        3
+      ],
+      "coeff": "qq3_2333",
+      "comment": "# Cqq32x3x3x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        1
+      ],
+      "coeff": "qq3_3111",
+      "comment": "# Cqq33x1x1x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        2
+      ],
+      "coeff": "qq3_3112",
+      "comment": "# Cqq33x1x1x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        3
+      ],
+      "coeff": "qq3_3113",
+      "comment": "# Cqq33x1x1x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        1
+      ],
+      "coeff": "qq3_3121",
+      "comment": "# Cqq33x1x2x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        2
+      ],
+      "coeff": "qq3_3122",
+      "comment": "# Cqq33x1x2x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        3
+      ],
+      "coeff": "qq3_3123",
+      "comment": "# Cqq33x1x2x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        1
+      ],
+      "coeff": "qq3_3131",
+      "comment": "# Cqq33x1x3x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        2
+      ],
+      "coeff": "qq3_3132",
+      "comment": "# Cqq33x1x3x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        3
+      ],
+      "coeff": "qq3_3133",
+      "comment": "# Cqq33x1x3x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        1
+      ],
+      "coeff": "qq3_3211",
+      "comment": "# Cqq33x2x1x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        2
+      ],
+      "coeff": "qq3_3212",
+      "comment": "# Cqq33x2x1x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        3
+      ],
+      "coeff": "qq3_3213",
+      "comment": "# Cqq33x2x1x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        1
+      ],
+      "coeff": "qq3_3221",
+      "comment": "# Cqq33x2x2x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        2
+      ],
+      "coeff": "qq3_3222",
+      "comment": "# Cqq33x2x2x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        3
+      ],
+      "coeff": "qq3_3223",
+      "comment": "# Cqq33x2x2x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "coeff": "qq3_3231",
+      "comment": "# Cqq33x2x3x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        2
+      ],
+      "coeff": "qq3_3232",
+      "comment": "# Cqq33x2x3x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        3
+      ],
+      "coeff": "qq3_3233",
+      "comment": "# Cqq33x2x3x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        1
+      ],
+      "coeff": "qq3_3311",
+      "comment": "# Cqq33x3x1x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        2
+      ],
+      "coeff": "qq3_3312",
+      "comment": "# Cqq33x3x1x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        3
+      ],
+      "coeff": "qq3_3313",
+      "comment": "# Cqq33x3x1x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        1
+      ],
+      "coeff": "qq3_3321",
+      "comment": "# Cqq33x3x2x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        2
+      ],
+      "coeff": "qq3_3322",
+      "comment": "# Cqq33x3x2x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        3
+      ],
+      "coeff": "qq3_3323",
+      "comment": "# Cqq33x3x2x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        1
+      ],
+      "coeff": "qq3_3331",
+      "comment": "# Cqq33x3x3x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        2
+      ],
+      "coeff": "qq3_3332",
+      "comment": "# Cqq33x3x3x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        3
+      ],
+      "coeff": "qq3_3333",
+      "comment": "# Cqq33x3x3x3 "
+    }
+  ],
+  "frblock44": [
+    {
+      "index": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "coeff": "qqql_1111",
+      "comment": "# Cqqq1x1x1x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        2
+      ],
+      "coeff": "qqql_1112",
+      "comment": "# Cqqq1x1x1x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        3
+      ],
+      "coeff": "qqql_1113",
+      "comment": "# Cqqq1x1x1x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        1
+      ],
+      "coeff": "qqql_1121",
+      "comment": "# Cqqq1x1x2x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "coeff": "qqql_1122",
+      "comment": "# Cqqq1x1x2x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "coeff": "qqql_1123",
+      "comment": "# Cqqq1x1x2x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        1
+      ],
+      "coeff": "qqql_1131",
+      "comment": "# Cqqq1x1x3x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        2
+      ],
+      "coeff": "qqql_1132",
+      "comment": "# Cqqq1x1x3x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        3
+      ],
+      "coeff": "qqql_1133",
+      "comment": "# Cqqq1x1x3x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        1
+      ],
+      "coeff": "qqql_1211",
+      "comment": "# Cqqq1x2x1x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        2
+      ],
+      "coeff": "qqql_1212",
+      "comment": "# Cqqq1x2x1x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        3
+      ],
+      "coeff": "qqql_1213",
+      "comment": "# Cqqq1x2x1x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        1
+      ],
+      "coeff": "qqql_1221",
+      "comment": "# Cqqq1x2x2x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        2
+      ],
+      "coeff": "qqql_1222",
+      "comment": "# Cqqq1x2x2x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        3
+      ],
+      "coeff": "qqql_1223",
+      "comment": "# Cqqq1x2x2x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        1
+      ],
+      "coeff": "qqql_1231",
+      "comment": "# Cqqq1x2x3x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        2
+      ],
+      "coeff": "qqql_1232",
+      "comment": "# Cqqq1x2x3x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        3
+      ],
+      "coeff": "qqql_1233",
+      "comment": "# Cqqq1x2x3x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        1
+      ],
+      "coeff": "qqql_1311",
+      "comment": "# Cqqq1x3x1x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        2
+      ],
+      "coeff": "qqql_1312",
+      "comment": "# Cqqq1x3x1x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        3
+      ],
+      "coeff": "qqql_1313",
+      "comment": "# Cqqq1x3x1x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        1
+      ],
+      "coeff": "qqql_1321",
+      "comment": "# Cqqq1x3x2x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        2
+      ],
+      "coeff": "qqql_1322",
+      "comment": "# Cqqq1x3x2x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        3
+      ],
+      "coeff": "qqql_1323",
+      "comment": "# Cqqq1x3x2x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        1
+      ],
+      "coeff": "qqql_1331",
+      "comment": "# Cqqq1x3x3x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        2
+      ],
+      "coeff": "qqql_1332",
+      "comment": "# Cqqq1x3x3x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        3
+      ],
+      "coeff": "qqql_1333",
+      "comment": "# Cqqq1x3x3x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "coeff": "qqql_2111",
+      "comment": "# Cqqq2x1x1x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        2
+      ],
+      "coeff": "qqql_2112",
+      "comment": "# Cqqq2x1x1x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        3
+      ],
+      "coeff": "qqql_2113",
+      "comment": "# Cqqq2x1x1x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "coeff": "qqql_2121",
+      "comment": "# Cqqq2x1x2x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        2
+      ],
+      "coeff": "qqql_2122",
+      "comment": "# Cqqq2x1x2x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "coeff": "qqql_2123",
+      "comment": "# Cqqq2x1x2x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        1
+      ],
+      "coeff": "qqql_2131",
+      "comment": "# Cqqq2x1x3x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        2
+      ],
+      "coeff": "qqql_2132",
+      "comment": "# Cqqq2x1x3x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        3
+      ],
+      "coeff": "qqql_2133",
+      "comment": "# Cqqq2x1x3x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        1
+      ],
+      "coeff": "qqql_2211",
+      "comment": "# Cqqq2x2x1x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        2
+      ],
+      "coeff": "qqql_2212",
+      "comment": "# Cqqq2x2x1x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        3
+      ],
+      "coeff": "qqql_2213",
+      "comment": "# Cqqq2x2x1x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        1
+      ],
+      "coeff": "qqql_2221",
+      "comment": "# Cqqq2x2x2x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "coeff": "qqql_2222",
+      "comment": "# Cqqq2x2x2x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        3
+      ],
+      "coeff": "qqql_2223",
+      "comment": "# Cqqq2x2x2x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        1
+      ],
+      "coeff": "qqql_2231",
+      "comment": "# Cqqq2x2x3x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        2
+      ],
+      "coeff": "qqql_2232",
+      "comment": "# Cqqq2x2x3x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        3
+      ],
+      "coeff": "qqql_2233",
+      "comment": "# Cqqq2x2x3x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        1
+      ],
+      "coeff": "qqql_2311",
+      "comment": "# Cqqq2x3x1x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        2
+      ],
+      "coeff": "qqql_2312",
+      "comment": "# Cqqq2x3x1x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        3
+      ],
+      "coeff": "qqql_2313",
+      "comment": "# Cqqq2x3x1x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        1
+      ],
+      "coeff": "qqql_2321",
+      "comment": "# Cqqq2x3x2x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        2
+      ],
+      "coeff": "qqql_2322",
+      "comment": "# Cqqq2x3x2x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        3
+      ],
+      "coeff": "qqql_2323",
+      "comment": "# Cqqq2x3x2x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        1
+      ],
+      "coeff": "qqql_2331",
+      "comment": "# Cqqq2x3x3x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        2
+      ],
+      "coeff": "qqql_2332",
+      "comment": "# Cqqq2x3x3x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        3
+      ],
+      "coeff": "qqql_2333",
+      "comment": "# Cqqq2x3x3x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        1
+      ],
+      "coeff": "qqql_3111",
+      "comment": "# Cqqq3x1x1x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        2
+      ],
+      "coeff": "qqql_3112",
+      "comment": "# Cqqq3x1x1x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        3
+      ],
+      "coeff": "qqql_3113",
+      "comment": "# Cqqq3x1x1x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        1
+      ],
+      "coeff": "qqql_3121",
+      "comment": "# Cqqq3x1x2x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        2
+      ],
+      "coeff": "qqql_3122",
+      "comment": "# Cqqq3x1x2x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        3
+      ],
+      "coeff": "qqql_3123",
+      "comment": "# Cqqq3x1x2x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        1
+      ],
+      "coeff": "qqql_3131",
+      "comment": "# Cqqq3x1x3x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        2
+      ],
+      "coeff": "qqql_3132",
+      "comment": "# Cqqq3x1x3x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        3
+      ],
+      "coeff": "qqql_3133",
+      "comment": "# Cqqq3x1x3x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        1
+      ],
+      "coeff": "qqql_3211",
+      "comment": "# Cqqq3x2x1x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        2
+      ],
+      "coeff": "qqql_3212",
+      "comment": "# Cqqq3x2x1x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        3
+      ],
+      "coeff": "qqql_3213",
+      "comment": "# Cqqq3x2x1x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        1
+      ],
+      "coeff": "qqql_3221",
+      "comment": "# Cqqq3x2x2x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        2
+      ],
+      "coeff": "qqql_3222",
+      "comment": "# Cqqq3x2x2x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        3
+      ],
+      "coeff": "qqql_3223",
+      "comment": "# Cqqq3x2x2x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "coeff": "qqql_3231",
+      "comment": "# Cqqq3x2x3x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        2
+      ],
+      "coeff": "qqql_3232",
+      "comment": "# Cqqq3x2x3x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        3
+      ],
+      "coeff": "qqql_3233",
+      "comment": "# Cqqq3x2x3x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        1
+      ],
+      "coeff": "qqql_3311",
+      "comment": "# Cqqq3x3x1x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        2
+      ],
+      "coeff": "qqql_3312",
+      "comment": "# Cqqq3x3x1x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        3
+      ],
+      "coeff": "qqql_3313",
+      "comment": "# Cqqq3x3x1x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        1
+      ],
+      "coeff": "qqql_3321",
+      "comment": "# Cqqq3x3x2x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        2
+      ],
+      "coeff": "qqql_3322",
+      "comment": "# Cqqq3x3x2x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        3
+      ],
+      "coeff": "qqql_3323",
+      "comment": "# Cqqq3x3x2x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        1
+      ],
+      "coeff": "qqql_3331",
+      "comment": "# Cqqq3x3x3x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        2
+      ],
+      "coeff": "qqql_3332",
+      "comment": "# Cqqq3x3x3x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        3
+      ],
+      "coeff": "qqql_3333",
+      "comment": "# Cqqq3x3x3x3 "
+    }
+  ],
+  "frblock45": [
+    {
+      "index": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "coeff": "qque_1111",
+      "comment": "# Cqqu1x1x1x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        2
+      ],
+      "coeff": "qque_1112",
+      "comment": "# Cqqu1x1x1x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        3
+      ],
+      "coeff": "qque_1113",
+      "comment": "# Cqqu1x1x1x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        1
+      ],
+      "coeff": "qque_1121",
+      "comment": "# Cqqu1x1x2x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "coeff": "qque_1122",
+      "comment": "# Cqqu1x1x2x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "coeff": "qque_1123",
+      "comment": "# Cqqu1x1x2x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        1
+      ],
+      "coeff": "qque_1131",
+      "comment": "# Cqqu1x1x3x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        2
+      ],
+      "coeff": "qque_1132",
+      "comment": "# Cqqu1x1x3x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        3
+      ],
+      "coeff": "qque_1133",
+      "comment": "# Cqqu1x1x3x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        1
+      ],
+      "coeff": "qque_1211",
+      "comment": "# Cqqu1x2x1x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        2
+      ],
+      "coeff": "qque_1212",
+      "comment": "# Cqqu1x2x1x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        3
+      ],
+      "coeff": "qque_1213",
+      "comment": "# Cqqu1x2x1x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        1
+      ],
+      "coeff": "qque_1221",
+      "comment": "# Cqqu1x2x2x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        2
+      ],
+      "coeff": "qque_1222",
+      "comment": "# Cqqu1x2x2x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        3
+      ],
+      "coeff": "qque_1223",
+      "comment": "# Cqqu1x2x2x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        1
+      ],
+      "coeff": "qque_1231",
+      "comment": "# Cqqu1x2x3x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        2
+      ],
+      "coeff": "qque_1232",
+      "comment": "# Cqqu1x2x3x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        3
+      ],
+      "coeff": "qque_1233",
+      "comment": "# Cqqu1x2x3x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        1
+      ],
+      "coeff": "qque_1311",
+      "comment": "# Cqqu1x3x1x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        2
+      ],
+      "coeff": "qque_1312",
+      "comment": "# Cqqu1x3x1x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        3
+      ],
+      "coeff": "qque_1313",
+      "comment": "# Cqqu1x3x1x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        1
+      ],
+      "coeff": "qque_1321",
+      "comment": "# Cqqu1x3x2x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        2
+      ],
+      "coeff": "qque_1322",
+      "comment": "# Cqqu1x3x2x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        3
+      ],
+      "coeff": "qque_1323",
+      "comment": "# Cqqu1x3x2x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        1
+      ],
+      "coeff": "qque_1331",
+      "comment": "# Cqqu1x3x3x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        2
+      ],
+      "coeff": "qque_1332",
+      "comment": "# Cqqu1x3x3x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        3
+      ],
+      "coeff": "qque_1333",
+      "comment": "# Cqqu1x3x3x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "coeff": "qque_2111",
+      "comment": "# Cqqu2x1x1x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        2
+      ],
+      "coeff": "qque_2112",
+      "comment": "# Cqqu2x1x1x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        3
+      ],
+      "coeff": "qque_2113",
+      "comment": "# Cqqu2x1x1x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "coeff": "qque_2121",
+      "comment": "# Cqqu2x1x2x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        2
+      ],
+      "coeff": "qque_2122",
+      "comment": "# Cqqu2x1x2x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "coeff": "qque_2123",
+      "comment": "# Cqqu2x1x2x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        1
+      ],
+      "coeff": "qque_2131",
+      "comment": "# Cqqu2x1x3x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        2
+      ],
+      "coeff": "qque_2132",
+      "comment": "# Cqqu2x1x3x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        3
+      ],
+      "coeff": "qque_2133",
+      "comment": "# Cqqu2x1x3x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        1
+      ],
+      "coeff": "qque_2211",
+      "comment": "# Cqqu2x2x1x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        2
+      ],
+      "coeff": "qque_2212",
+      "comment": "# Cqqu2x2x1x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        3
+      ],
+      "coeff": "qque_2213",
+      "comment": "# Cqqu2x2x1x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        1
+      ],
+      "coeff": "qque_2221",
+      "comment": "# Cqqu2x2x2x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "coeff": "qque_2222",
+      "comment": "# Cqqu2x2x2x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        3
+      ],
+      "coeff": "qque_2223",
+      "comment": "# Cqqu2x2x2x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        1
+      ],
+      "coeff": "qque_2231",
+      "comment": "# Cqqu2x2x3x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        2
+      ],
+      "coeff": "qque_2232",
+      "comment": "# Cqqu2x2x3x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        3
+      ],
+      "coeff": "qque_2233",
+      "comment": "# Cqqu2x2x3x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        1
+      ],
+      "coeff": "qque_2311",
+      "comment": "# Cqqu2x3x1x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        2
+      ],
+      "coeff": "qque_2312",
+      "comment": "# Cqqu2x3x1x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        3
+      ],
+      "coeff": "qque_2313",
+      "comment": "# Cqqu2x3x1x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        1
+      ],
+      "coeff": "qque_2321",
+      "comment": "# Cqqu2x3x2x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        2
+      ],
+      "coeff": "qque_2322",
+      "comment": "# Cqqu2x3x2x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        3
+      ],
+      "coeff": "qque_2323",
+      "comment": "# Cqqu2x3x2x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        1
+      ],
+      "coeff": "qque_2331",
+      "comment": "# Cqqu2x3x3x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        2
+      ],
+      "coeff": "qque_2332",
+      "comment": "# Cqqu2x3x3x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        3
+      ],
+      "coeff": "qque_2333",
+      "comment": "# Cqqu2x3x3x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        1
+      ],
+      "coeff": "qque_3111",
+      "comment": "# Cqqu3x1x1x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        2
+      ],
+      "coeff": "qque_3112",
+      "comment": "# Cqqu3x1x1x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        3
+      ],
+      "coeff": "qque_3113",
+      "comment": "# Cqqu3x1x1x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        1
+      ],
+      "coeff": "qque_3121",
+      "comment": "# Cqqu3x1x2x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        2
+      ],
+      "coeff": "qque_3122",
+      "comment": "# Cqqu3x1x2x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        3
+      ],
+      "coeff": "qque_3123",
+      "comment": "# Cqqu3x1x2x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        1
+      ],
+      "coeff": "qque_3131",
+      "comment": "# Cqqu3x1x3x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        2
+      ],
+      "coeff": "qque_3132",
+      "comment": "# Cqqu3x1x3x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        3
+      ],
+      "coeff": "qque_3133",
+      "comment": "# Cqqu3x1x3x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        1
+      ],
+      "coeff": "qque_3211",
+      "comment": "# Cqqu3x2x1x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        2
+      ],
+      "coeff": "qque_3212",
+      "comment": "# Cqqu3x2x1x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        3
+      ],
+      "coeff": "qque_3213",
+      "comment": "# Cqqu3x2x1x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        1
+      ],
+      "coeff": "qque_3221",
+      "comment": "# Cqqu3x2x2x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        2
+      ],
+      "coeff": "qque_3222",
+      "comment": "# Cqqu3x2x2x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        3
+      ],
+      "coeff": "qque_3223",
+      "comment": "# Cqqu3x2x2x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "coeff": "qque_3231",
+      "comment": "# Cqqu3x2x3x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        2
+      ],
+      "coeff": "qque_3232",
+      "comment": "# Cqqu3x2x3x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        3
+      ],
+      "coeff": "qque_3233",
+      "comment": "# Cqqu3x2x3x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        1
+      ],
+      "coeff": "qque_3311",
+      "comment": "# Cqqu3x3x1x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        2
+      ],
+      "coeff": "qque_3312",
+      "comment": "# Cqqu3x3x1x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        3
+      ],
+      "coeff": "qque_3313",
+      "comment": "# Cqqu3x3x1x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        1
+      ],
+      "coeff": "qque_3321",
+      "comment": "# Cqqu3x3x2x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        2
+      ],
+      "coeff": "qque_3322",
+      "comment": "# Cqqu3x3x2x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        3
+      ],
+      "coeff": "qque_3323",
+      "comment": "# Cqqu3x3x2x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        1
+      ],
+      "coeff": "qque_3331",
+      "comment": "# Cqqu3x3x3x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        2
+      ],
+      "coeff": "qque_3332",
+      "comment": "# Cqqu3x3x3x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        3
+      ],
+      "coeff": "qque_3333",
+      "comment": "# Cqqu3x3x3x3 "
+    }
+  ],
+  "frblock46": [
+    {
+      "index": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "coeff": "qu1_1111",
+      "comment": "# Cqu11x1x1x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        2
+      ],
+      "coeff": "qu1_1112",
+      "comment": "# Cqu11x1x1x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        3
+      ],
+      "coeff": "qu1_1113",
+      "comment": "# Cqu11x1x1x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        1
+      ],
+      "coeff": "qu1_1121",
+      "comment": "# Cqu11x1x2x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "coeff": "qu1_1122",
+      "comment": "# Cqu11x1x2x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "coeff": "qu1_1123",
+      "comment": "# Cqu11x1x2x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        1
+      ],
+      "coeff": "qu1_1131",
+      "comment": "# Cqu11x1x3x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        2
+      ],
+      "coeff": "qu1_1132",
+      "comment": "# Cqu11x1x3x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        3
+      ],
+      "coeff": "qu1_1133",
+      "comment": "# Cqu11x1x3x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        1
+      ],
+      "coeff": "qu1_1211",
+      "comment": "# Cqu11x2x1x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        2
+      ],
+      "coeff": "qu1_1212",
+      "comment": "# Cqu11x2x1x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        3
+      ],
+      "coeff": "qu1_1213",
+      "comment": "# Cqu11x2x1x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        1
+      ],
+      "coeff": "qu1_1221",
+      "comment": "# Cqu11x2x2x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        2
+      ],
+      "coeff": "qu1_1222",
+      "comment": "# Cqu11x2x2x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        3
+      ],
+      "coeff": "qu1_1223",
+      "comment": "# Cqu11x2x2x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        1
+      ],
+      "coeff": "qu1_1231",
+      "comment": "# Cqu11x2x3x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        2
+      ],
+      "coeff": "qu1_1232",
+      "comment": "# Cqu11x2x3x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        3
+      ],
+      "coeff": "qu1_1233",
+      "comment": "# Cqu11x2x3x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        1
+      ],
+      "coeff": "qu1_1311",
+      "comment": "# Cqu11x3x1x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        2
+      ],
+      "coeff": "qu1_1312",
+      "comment": "# Cqu11x3x1x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        3
+      ],
+      "coeff": "qu1_1313",
+      "comment": "# Cqu11x3x1x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        1
+      ],
+      "coeff": "qu1_1321",
+      "comment": "# Cqu11x3x2x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        2
+      ],
+      "coeff": "qu1_1322",
+      "comment": "# Cqu11x3x2x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        3
+      ],
+      "coeff": "qu1_1323",
+      "comment": "# Cqu11x3x2x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        1
+      ],
+      "coeff": "qu1_1331",
+      "comment": "# Cqu11x3x3x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        2
+      ],
+      "coeff": "qu1_1332",
+      "comment": "# Cqu11x3x3x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        3
+      ],
+      "coeff": "qu1_1333",
+      "comment": "# Cqu11x3x3x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "coeff": "qu1_2111",
+      "comment": "# Cqu12x1x1x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        2
+      ],
+      "coeff": "qu1_2112",
+      "comment": "# Cqu12x1x1x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        3
+      ],
+      "coeff": "qu1_2113",
+      "comment": "# Cqu12x1x1x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "coeff": "qu1_2121",
+      "comment": "# Cqu12x1x2x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        2
+      ],
+      "coeff": "qu1_2122",
+      "comment": "# Cqu12x1x2x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "coeff": "qu1_2123",
+      "comment": "# Cqu12x1x2x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        1
+      ],
+      "coeff": "qu1_2131",
+      "comment": "# Cqu12x1x3x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        2
+      ],
+      "coeff": "qu1_2132",
+      "comment": "# Cqu12x1x3x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        3
+      ],
+      "coeff": "qu1_2133",
+      "comment": "# Cqu12x1x3x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        1
+      ],
+      "coeff": "qu1_2211",
+      "comment": "# Cqu12x2x1x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        2
+      ],
+      "coeff": "qu1_2212",
+      "comment": "# Cqu12x2x1x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        3
+      ],
+      "coeff": "qu1_2213",
+      "comment": "# Cqu12x2x1x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        1
+      ],
+      "coeff": "qu1_2221",
+      "comment": "# Cqu12x2x2x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "coeff": "qu1_2222",
+      "comment": "# Cqu12x2x2x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        3
+      ],
+      "coeff": "qu1_2223",
+      "comment": "# Cqu12x2x2x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        1
+      ],
+      "coeff": "qu1_2231",
+      "comment": "# Cqu12x2x3x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        2
+      ],
+      "coeff": "qu1_2232",
+      "comment": "# Cqu12x2x3x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        3
+      ],
+      "coeff": "qu1_2233",
+      "comment": "# Cqu12x2x3x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        1
+      ],
+      "coeff": "qu1_2311",
+      "comment": "# Cqu12x3x1x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        2
+      ],
+      "coeff": "qu1_2312",
+      "comment": "# Cqu12x3x1x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        3
+      ],
+      "coeff": "qu1_2313",
+      "comment": "# Cqu12x3x1x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        1
+      ],
+      "coeff": "qu1_2321",
+      "comment": "# Cqu12x3x2x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        2
+      ],
+      "coeff": "qu1_2322",
+      "comment": "# Cqu12x3x2x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        3
+      ],
+      "coeff": "qu1_2323",
+      "comment": "# Cqu12x3x2x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        1
+      ],
+      "coeff": "qu1_2331",
+      "comment": "# Cqu12x3x3x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        2
+      ],
+      "coeff": "qu1_2332",
+      "comment": "# Cqu12x3x3x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        3
+      ],
+      "coeff": "qu1_2333",
+      "comment": "# Cqu12x3x3x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        1
+      ],
+      "coeff": "qu1_3111",
+      "comment": "# Cqu13x1x1x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        2
+      ],
+      "coeff": "qu1_3112",
+      "comment": "# Cqu13x1x1x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        3
+      ],
+      "coeff": "qu1_3113",
+      "comment": "# Cqu13x1x1x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        1
+      ],
+      "coeff": "qu1_3121",
+      "comment": "# Cqu13x1x2x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        2
+      ],
+      "coeff": "qu1_3122",
+      "comment": "# Cqu13x1x2x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        3
+      ],
+      "coeff": "qu1_3123",
+      "comment": "# Cqu13x1x2x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        1
+      ],
+      "coeff": "qu1_3131",
+      "comment": "# Cqu13x1x3x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        2
+      ],
+      "coeff": "qu1_3132",
+      "comment": "# Cqu13x1x3x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        3
+      ],
+      "coeff": "qu1_3133",
+      "comment": "# Cqu13x1x3x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        1
+      ],
+      "coeff": "qu1_3211",
+      "comment": "# Cqu13x2x1x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        2
+      ],
+      "coeff": "qu1_3212",
+      "comment": "# Cqu13x2x1x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        3
+      ],
+      "coeff": "qu1_3213",
+      "comment": "# Cqu13x2x1x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        1
+      ],
+      "coeff": "qu1_3221",
+      "comment": "# Cqu13x2x2x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        2
+      ],
+      "coeff": "qu1_3222",
+      "comment": "# Cqu13x2x2x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        3
+      ],
+      "coeff": "qu1_3223",
+      "comment": "# Cqu13x2x2x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "coeff": "qu1_3231",
+      "comment": "# Cqu13x2x3x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        2
+      ],
+      "coeff": "qu1_3232",
+      "comment": "# Cqu13x2x3x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        3
+      ],
+      "coeff": "qu1_3233",
+      "comment": "# Cqu13x2x3x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        1
+      ],
+      "coeff": "qu1_3311",
+      "comment": "# Cqu13x3x1x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        2
+      ],
+      "coeff": "qu1_3312",
+      "comment": "# Cqu13x3x1x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        3
+      ],
+      "coeff": "qu1_3313",
+      "comment": "# Cqu13x3x1x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        1
+      ],
+      "coeff": "qu1_3321",
+      "comment": "# Cqu13x3x2x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        2
+      ],
+      "coeff": "qu1_3322",
+      "comment": "# Cqu13x3x2x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        3
+      ],
+      "coeff": "qu1_3323",
+      "comment": "# Cqu13x3x2x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        1
+      ],
+      "coeff": "qu1_3331",
+      "comment": "# Cqu13x3x3x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        2
+      ],
+      "coeff": "qu1_3332",
+      "comment": "# Cqu13x3x3x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        3
+      ],
+      "coeff": "qu1_3333",
+      "comment": "# Cqu13x3x3x3 "
+    }
+  ],
+  "frblock47": [
+    {
+      "index": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "coeff": "qu8_1111",
+      "comment": "# Cqu81x1x1x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        2
+      ],
+      "coeff": "qu8_1112",
+      "comment": "# Cqu81x1x1x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        3
+      ],
+      "coeff": "qu8_1113",
+      "comment": "# Cqu81x1x1x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        1
+      ],
+      "coeff": "qu8_1121",
+      "comment": "# Cqu81x1x2x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "coeff": "qu8_1122",
+      "comment": "# Cqu81x1x2x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "coeff": "qu8_1123",
+      "comment": "# Cqu81x1x2x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        1
+      ],
+      "coeff": "qu8_1131",
+      "comment": "# Cqu81x1x3x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        2
+      ],
+      "coeff": "qu8_1132",
+      "comment": "# Cqu81x1x3x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        3
+      ],
+      "coeff": "qu8_1133",
+      "comment": "# Cqu81x1x3x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        1
+      ],
+      "coeff": "qu8_1211",
+      "comment": "# Cqu81x2x1x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        2
+      ],
+      "coeff": "qu8_1212",
+      "comment": "# Cqu81x2x1x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        3
+      ],
+      "coeff": "qu8_1213",
+      "comment": "# Cqu81x2x1x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        1
+      ],
+      "coeff": "qu8_1221",
+      "comment": "# Cqu81x2x2x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        2
+      ],
+      "coeff": "qu8_1222",
+      "comment": "# Cqu81x2x2x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        3
+      ],
+      "coeff": "qu8_1223",
+      "comment": "# Cqu81x2x2x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        1
+      ],
+      "coeff": "qu8_1231",
+      "comment": "# Cqu81x2x3x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        2
+      ],
+      "coeff": "qu8_1232",
+      "comment": "# Cqu81x2x3x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        3
+      ],
+      "coeff": "qu8_1233",
+      "comment": "# Cqu81x2x3x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        1
+      ],
+      "coeff": "qu8_1311",
+      "comment": "# Cqu81x3x1x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        2
+      ],
+      "coeff": "qu8_1312",
+      "comment": "# Cqu81x3x1x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        3
+      ],
+      "coeff": "qu8_1313",
+      "comment": "# Cqu81x3x1x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        1
+      ],
+      "coeff": "qu8_1321",
+      "comment": "# Cqu81x3x2x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        2
+      ],
+      "coeff": "qu8_1322",
+      "comment": "# Cqu81x3x2x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        3
+      ],
+      "coeff": "qu8_1323",
+      "comment": "# Cqu81x3x2x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        1
+      ],
+      "coeff": "qu8_1331",
+      "comment": "# Cqu81x3x3x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        2
+      ],
+      "coeff": "qu8_1332",
+      "comment": "# Cqu81x3x3x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        3
+      ],
+      "coeff": "qu8_1333",
+      "comment": "# Cqu81x3x3x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "coeff": "qu8_2111",
+      "comment": "# Cqu82x1x1x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        2
+      ],
+      "coeff": "qu8_2112",
+      "comment": "# Cqu82x1x1x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        3
+      ],
+      "coeff": "qu8_2113",
+      "comment": "# Cqu82x1x1x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "coeff": "qu8_2121",
+      "comment": "# Cqu82x1x2x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        2
+      ],
+      "coeff": "qu8_2122",
+      "comment": "# Cqu82x1x2x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "coeff": "qu8_2123",
+      "comment": "# Cqu82x1x2x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        1
+      ],
+      "coeff": "qu8_2131",
+      "comment": "# Cqu82x1x3x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        2
+      ],
+      "coeff": "qu8_2132",
+      "comment": "# Cqu82x1x3x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        3
+      ],
+      "coeff": "qu8_2133",
+      "comment": "# Cqu82x1x3x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        1
+      ],
+      "coeff": "qu8_2211",
+      "comment": "# Cqu82x2x1x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        2
+      ],
+      "coeff": "qu8_2212",
+      "comment": "# Cqu82x2x1x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        3
+      ],
+      "coeff": "qu8_2213",
+      "comment": "# Cqu82x2x1x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        1
+      ],
+      "coeff": "qu8_2221",
+      "comment": "# Cqu82x2x2x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "coeff": "qu8_2222",
+      "comment": "# Cqu82x2x2x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        3
+      ],
+      "coeff": "qu8_2223",
+      "comment": "# Cqu82x2x2x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        1
+      ],
+      "coeff": "qu8_2231",
+      "comment": "# Cqu82x2x3x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        2
+      ],
+      "coeff": "qu8_2232",
+      "comment": "# Cqu82x2x3x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        3
+      ],
+      "coeff": "qu8_2233",
+      "comment": "# Cqu82x2x3x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        1
+      ],
+      "coeff": "qu8_2311",
+      "comment": "# Cqu82x3x1x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        2
+      ],
+      "coeff": "qu8_2312",
+      "comment": "# Cqu82x3x1x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        3
+      ],
+      "coeff": "qu8_2313",
+      "comment": "# Cqu82x3x1x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        1
+      ],
+      "coeff": "qu8_2321",
+      "comment": "# Cqu82x3x2x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        2
+      ],
+      "coeff": "qu8_2322",
+      "comment": "# Cqu82x3x2x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        3
+      ],
+      "coeff": "qu8_2323",
+      "comment": "# Cqu82x3x2x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        1
+      ],
+      "coeff": "qu8_2331",
+      "comment": "# Cqu82x3x3x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        2
+      ],
+      "coeff": "qu8_2332",
+      "comment": "# Cqu82x3x3x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        3
+      ],
+      "coeff": "qu8_2333",
+      "comment": "# Cqu82x3x3x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        1
+      ],
+      "coeff": "qu8_3111",
+      "comment": "# Cqu83x1x1x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        2
+      ],
+      "coeff": "qu8_3112",
+      "comment": "# Cqu83x1x1x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        3
+      ],
+      "coeff": "qu8_3113",
+      "comment": "# Cqu83x1x1x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        1
+      ],
+      "coeff": "qu8_3121",
+      "comment": "# Cqu83x1x2x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        2
+      ],
+      "coeff": "qu8_3122",
+      "comment": "# Cqu83x1x2x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        3
+      ],
+      "coeff": "qu8_3123",
+      "comment": "# Cqu83x1x2x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        1
+      ],
+      "coeff": "qu8_3131",
+      "comment": "# Cqu83x1x3x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        2
+      ],
+      "coeff": "qu8_3132",
+      "comment": "# Cqu83x1x3x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        3
+      ],
+      "coeff": "qu8_3133",
+      "comment": "# Cqu83x1x3x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        1
+      ],
+      "coeff": "qu8_3211",
+      "comment": "# Cqu83x2x1x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        2
+      ],
+      "coeff": "qu8_3212",
+      "comment": "# Cqu83x2x1x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        3
+      ],
+      "coeff": "qu8_3213",
+      "comment": "# Cqu83x2x1x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        1
+      ],
+      "coeff": "qu8_3221",
+      "comment": "# Cqu83x2x2x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        2
+      ],
+      "coeff": "qu8_3222",
+      "comment": "# Cqu83x2x2x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        3
+      ],
+      "coeff": "qu8_3223",
+      "comment": "# Cqu83x2x2x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "coeff": "qu8_3231",
+      "comment": "# Cqu83x2x3x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        2
+      ],
+      "coeff": "qu8_3232",
+      "comment": "# Cqu83x2x3x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        3
+      ],
+      "coeff": "qu8_3233",
+      "comment": "# Cqu83x2x3x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        1
+      ],
+      "coeff": "qu8_3311",
+      "comment": "# Cqu83x3x1x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        2
+      ],
+      "coeff": "qu8_3312",
+      "comment": "# Cqu83x3x1x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        3
+      ],
+      "coeff": "qu8_3313",
+      "comment": "# Cqu83x3x1x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        1
+      ],
+      "coeff": "qu8_3321",
+      "comment": "# Cqu83x3x2x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        2
+      ],
+      "coeff": "qu8_3322",
+      "comment": "# Cqu83x3x2x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        3
+      ],
+      "coeff": "qu8_3323",
+      "comment": "# Cqu83x3x2x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        1
+      ],
+      "coeff": "qu8_3331",
+      "comment": "# Cqu83x3x3x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        2
+      ],
+      "coeff": "qu8_3332",
+      "comment": "# Cqu83x3x3x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        3
+      ],
+      "coeff": "qu8_3333",
+      "comment": "# Cqu83x3x3x3 "
+    }
+  ],
+  "frblock48": [
+    {
+      "index": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "coeff": "quqd1_1111",
+      "comment": "# Cquqd11x1x1x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        2
+      ],
+      "coeff": "quqd1_1112",
+      "comment": "# Cquqd11x1x1x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        3
+      ],
+      "coeff": "quqd1_1113",
+      "comment": "# Cquqd11x1x1x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        1
+      ],
+      "coeff": "quqd1_1121",
+      "comment": "# Cquqd11x1x2x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "coeff": "quqd1_1122",
+      "comment": "# Cquqd11x1x2x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "coeff": "quqd1_1123",
+      "comment": "# Cquqd11x1x2x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        1
+      ],
+      "coeff": "quqd1_1131",
+      "comment": "# Cquqd11x1x3x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        2
+      ],
+      "coeff": "quqd1_1132",
+      "comment": "# Cquqd11x1x3x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        3
+      ],
+      "coeff": "quqd1_1133",
+      "comment": "# Cquqd11x1x3x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        1
+      ],
+      "coeff": "quqd1_1211",
+      "comment": "# Cquqd11x2x1x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        2
+      ],
+      "coeff": "quqd1_1212",
+      "comment": "# Cquqd11x2x1x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        3
+      ],
+      "coeff": "quqd1_1213",
+      "comment": "# Cquqd11x2x1x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        1
+      ],
+      "coeff": "quqd1_1221",
+      "comment": "# Cquqd11x2x2x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        2
+      ],
+      "coeff": "quqd1_1222",
+      "comment": "# Cquqd11x2x2x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        3
+      ],
+      "coeff": "quqd1_1223",
+      "comment": "# Cquqd11x2x2x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        1
+      ],
+      "coeff": "quqd1_1231",
+      "comment": "# Cquqd11x2x3x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        2
+      ],
+      "coeff": "quqd1_1232",
+      "comment": "# Cquqd11x2x3x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        3
+      ],
+      "coeff": "quqd1_1233",
+      "comment": "# Cquqd11x2x3x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        1
+      ],
+      "coeff": "quqd1_1311",
+      "comment": "# Cquqd11x3x1x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        2
+      ],
+      "coeff": "quqd1_1312",
+      "comment": "# Cquqd11x3x1x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        3
+      ],
+      "coeff": "quqd1_1313",
+      "comment": "# Cquqd11x3x1x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        1
+      ],
+      "coeff": "quqd1_1321",
+      "comment": "# Cquqd11x3x2x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        2
+      ],
+      "coeff": "quqd1_1322",
+      "comment": "# Cquqd11x3x2x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        3
+      ],
+      "coeff": "quqd1_1323",
+      "comment": "# Cquqd11x3x2x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        1
+      ],
+      "coeff": "quqd1_1331",
+      "comment": "# Cquqd11x3x3x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        2
+      ],
+      "coeff": "quqd1_1332",
+      "comment": "# Cquqd11x3x3x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        3
+      ],
+      "coeff": "quqd1_1333",
+      "comment": "# Cquqd11x3x3x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "coeff": "quqd1_2111",
+      "comment": "# Cquqd12x1x1x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        2
+      ],
+      "coeff": "quqd1_2112",
+      "comment": "# Cquqd12x1x1x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        3
+      ],
+      "coeff": "quqd1_2113",
+      "comment": "# Cquqd12x1x1x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "coeff": "quqd1_2121",
+      "comment": "# Cquqd12x1x2x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        2
+      ],
+      "coeff": "quqd1_2122",
+      "comment": "# Cquqd12x1x2x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "coeff": "quqd1_2123",
+      "comment": "# Cquqd12x1x2x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        1
+      ],
+      "coeff": "quqd1_2131",
+      "comment": "# Cquqd12x1x3x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        2
+      ],
+      "coeff": "quqd1_2132",
+      "comment": "# Cquqd12x1x3x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        3
+      ],
+      "coeff": "quqd1_2133",
+      "comment": "# Cquqd12x1x3x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        1
+      ],
+      "coeff": "quqd1_2211",
+      "comment": "# Cquqd12x2x1x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        2
+      ],
+      "coeff": "quqd1_2212",
+      "comment": "# Cquqd12x2x1x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        3
+      ],
+      "coeff": "quqd1_2213",
+      "comment": "# Cquqd12x2x1x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        1
+      ],
+      "coeff": "quqd1_2221",
+      "comment": "# Cquqd12x2x2x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "coeff": "quqd1_2222",
+      "comment": "# Cquqd12x2x2x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        3
+      ],
+      "coeff": "quqd1_2223",
+      "comment": "# Cquqd12x2x2x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        1
+      ],
+      "coeff": "quqd1_2231",
+      "comment": "# Cquqd12x2x3x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        2
+      ],
+      "coeff": "quqd1_2232",
+      "comment": "# Cquqd12x2x3x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        3
+      ],
+      "coeff": "quqd1_2233",
+      "comment": "# Cquqd12x2x3x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        1
+      ],
+      "coeff": "quqd1_2311",
+      "comment": "# Cquqd12x3x1x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        2
+      ],
+      "coeff": "quqd1_2312",
+      "comment": "# Cquqd12x3x1x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        3
+      ],
+      "coeff": "quqd1_2313",
+      "comment": "# Cquqd12x3x1x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        1
+      ],
+      "coeff": "quqd1_2321",
+      "comment": "# Cquqd12x3x2x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        2
+      ],
+      "coeff": "quqd1_2322",
+      "comment": "# Cquqd12x3x2x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        3
+      ],
+      "coeff": "quqd1_2323",
+      "comment": "# Cquqd12x3x2x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        1
+      ],
+      "coeff": "quqd1_2331",
+      "comment": "# Cquqd12x3x3x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        2
+      ],
+      "coeff": "quqd1_2332",
+      "comment": "# Cquqd12x3x3x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        3
+      ],
+      "coeff": "quqd1_2333",
+      "comment": "# Cquqd12x3x3x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        1
+      ],
+      "coeff": "quqd1_3111",
+      "comment": "# Cquqd13x1x1x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        2
+      ],
+      "coeff": "quqd1_3112",
+      "comment": "# Cquqd13x1x1x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        3
+      ],
+      "coeff": "quqd1_3113",
+      "comment": "# Cquqd13x1x1x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        1
+      ],
+      "coeff": "quqd1_3121",
+      "comment": "# Cquqd13x1x2x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        2
+      ],
+      "coeff": "quqd1_3122",
+      "comment": "# Cquqd13x1x2x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        3
+      ],
+      "coeff": "quqd1_3123",
+      "comment": "# Cquqd13x1x2x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        1
+      ],
+      "coeff": "quqd1_3131",
+      "comment": "# Cquqd13x1x3x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        2
+      ],
+      "coeff": "quqd1_3132",
+      "comment": "# Cquqd13x1x3x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        3
+      ],
+      "coeff": "quqd1_3133",
+      "comment": "# Cquqd13x1x3x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        1
+      ],
+      "coeff": "quqd1_3211",
+      "comment": "# Cquqd13x2x1x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        2
+      ],
+      "coeff": "quqd1_3212",
+      "comment": "# Cquqd13x2x1x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        3
+      ],
+      "coeff": "quqd1_3213",
+      "comment": "# Cquqd13x2x1x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        1
+      ],
+      "coeff": "quqd1_3221",
+      "comment": "# Cquqd13x2x2x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        2
+      ],
+      "coeff": "quqd1_3222",
+      "comment": "# Cquqd13x2x2x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        3
+      ],
+      "coeff": "quqd1_3223",
+      "comment": "# Cquqd13x2x2x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "coeff": "quqd1_3231",
+      "comment": "# Cquqd13x2x3x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        2
+      ],
+      "coeff": "quqd1_3232",
+      "comment": "# Cquqd13x2x3x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        3
+      ],
+      "coeff": "quqd1_3233",
+      "comment": "# Cquqd13x2x3x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        1
+      ],
+      "coeff": "quqd1_3311",
+      "comment": "# Cquqd13x3x1x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        2
+      ],
+      "coeff": "quqd1_3312",
+      "comment": "# Cquqd13x3x1x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        3
+      ],
+      "coeff": "quqd1_3313",
+      "comment": "# Cquqd13x3x1x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        1
+      ],
+      "coeff": "quqd1_3321",
+      "comment": "# Cquqd13x3x2x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        2
+      ],
+      "coeff": "quqd1_3322",
+      "comment": "# Cquqd13x3x2x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        3
+      ],
+      "coeff": "quqd1_3323",
+      "comment": "# Cquqd13x3x2x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        1
+      ],
+      "coeff": "quqd1_3331",
+      "comment": "# Cquqd13x3x3x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        2
+      ],
+      "coeff": "quqd1_3332",
+      "comment": "# Cquqd13x3x3x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        3
+      ],
+      "coeff": "quqd1_3333",
+      "comment": "# Cquqd13x3x3x3 "
+    }
+  ],
+  "frblock49": [
+    {
+      "index": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "coeff": "quqd8_1111",
+      "comment": "# Cquqd81x1x1x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        2
+      ],
+      "coeff": "quqd8_1112",
+      "comment": "# Cquqd81x1x1x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        3
+      ],
+      "coeff": "quqd8_1113",
+      "comment": "# Cquqd81x1x1x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        1
+      ],
+      "coeff": "quqd8_1121",
+      "comment": "# Cquqd81x1x2x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "coeff": "quqd8_1122",
+      "comment": "# Cquqd81x1x2x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "coeff": "quqd8_1123",
+      "comment": "# Cquqd81x1x2x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        1
+      ],
+      "coeff": "quqd8_1131",
+      "comment": "# Cquqd81x1x3x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        2
+      ],
+      "coeff": "quqd8_1132",
+      "comment": "# Cquqd81x1x3x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        3
+      ],
+      "coeff": "quqd8_1133",
+      "comment": "# Cquqd81x1x3x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        1
+      ],
+      "coeff": "quqd8_1211",
+      "comment": "# Cquqd81x2x1x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        2
+      ],
+      "coeff": "quqd8_1212",
+      "comment": "# Cquqd81x2x1x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        3
+      ],
+      "coeff": "quqd8_1213",
+      "comment": "# Cquqd81x2x1x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        1
+      ],
+      "coeff": "quqd8_1221",
+      "comment": "# Cquqd81x2x2x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        2
+      ],
+      "coeff": "quqd8_1222",
+      "comment": "# Cquqd81x2x2x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        3
+      ],
+      "coeff": "quqd8_1223",
+      "comment": "# Cquqd81x2x2x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        1
+      ],
+      "coeff": "quqd8_1231",
+      "comment": "# Cquqd81x2x3x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        2
+      ],
+      "coeff": "quqd8_1232",
+      "comment": "# Cquqd81x2x3x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        3
+      ],
+      "coeff": "quqd8_1233",
+      "comment": "# Cquqd81x2x3x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        1
+      ],
+      "coeff": "quqd8_1311",
+      "comment": "# Cquqd81x3x1x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        2
+      ],
+      "coeff": "quqd8_1312",
+      "comment": "# Cquqd81x3x1x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        3
+      ],
+      "coeff": "quqd8_1313",
+      "comment": "# Cquqd81x3x1x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        1
+      ],
+      "coeff": "quqd8_1321",
+      "comment": "# Cquqd81x3x2x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        2
+      ],
+      "coeff": "quqd8_1322",
+      "comment": "# Cquqd81x3x2x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        3
+      ],
+      "coeff": "quqd8_1323",
+      "comment": "# Cquqd81x3x2x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        1
+      ],
+      "coeff": "quqd8_1331",
+      "comment": "# Cquqd81x3x3x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        2
+      ],
+      "coeff": "quqd8_1332",
+      "comment": "# Cquqd81x3x3x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        3
+      ],
+      "coeff": "quqd8_1333",
+      "comment": "# Cquqd81x3x3x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "coeff": "quqd8_2111",
+      "comment": "# Cquqd82x1x1x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        2
+      ],
+      "coeff": "quqd8_2112",
+      "comment": "# Cquqd82x1x1x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        3
+      ],
+      "coeff": "quqd8_2113",
+      "comment": "# Cquqd82x1x1x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "coeff": "quqd8_2121",
+      "comment": "# Cquqd82x1x2x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        2
+      ],
+      "coeff": "quqd8_2122",
+      "comment": "# Cquqd82x1x2x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "coeff": "quqd8_2123",
+      "comment": "# Cquqd82x1x2x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        1
+      ],
+      "coeff": "quqd8_2131",
+      "comment": "# Cquqd82x1x3x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        2
+      ],
+      "coeff": "quqd8_2132",
+      "comment": "# Cquqd82x1x3x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        3
+      ],
+      "coeff": "quqd8_2133",
+      "comment": "# Cquqd82x1x3x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        1
+      ],
+      "coeff": "quqd8_2211",
+      "comment": "# Cquqd82x2x1x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        2
+      ],
+      "coeff": "quqd8_2212",
+      "comment": "# Cquqd82x2x1x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        3
+      ],
+      "coeff": "quqd8_2213",
+      "comment": "# Cquqd82x2x1x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        1
+      ],
+      "coeff": "quqd8_2221",
+      "comment": "# Cquqd82x2x2x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "coeff": "quqd8_2222",
+      "comment": "# Cquqd82x2x2x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        3
+      ],
+      "coeff": "quqd8_2223",
+      "comment": "# Cquqd82x2x2x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        1
+      ],
+      "coeff": "quqd8_2231",
+      "comment": "# Cquqd82x2x3x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        2
+      ],
+      "coeff": "quqd8_2232",
+      "comment": "# Cquqd82x2x3x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        3
+      ],
+      "coeff": "quqd8_2233",
+      "comment": "# Cquqd82x2x3x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        1
+      ],
+      "coeff": "quqd8_2311",
+      "comment": "# Cquqd82x3x1x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        2
+      ],
+      "coeff": "quqd8_2312",
+      "comment": "# Cquqd82x3x1x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        3
+      ],
+      "coeff": "quqd8_2313",
+      "comment": "# Cquqd82x3x1x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        1
+      ],
+      "coeff": "quqd8_2321",
+      "comment": "# Cquqd82x3x2x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        2
+      ],
+      "coeff": "quqd8_2322",
+      "comment": "# Cquqd82x3x2x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        3
+      ],
+      "coeff": "quqd8_2323",
+      "comment": "# Cquqd82x3x2x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        1
+      ],
+      "coeff": "quqd8_2331",
+      "comment": "# Cquqd82x3x3x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        2
+      ],
+      "coeff": "quqd8_2332",
+      "comment": "# Cquqd82x3x3x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        3
+      ],
+      "coeff": "quqd8_2333",
+      "comment": "# Cquqd82x3x3x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        1
+      ],
+      "coeff": "quqd8_3111",
+      "comment": "# Cquqd83x1x1x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        2
+      ],
+      "coeff": "quqd8_3112",
+      "comment": "# Cquqd83x1x1x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        3
+      ],
+      "coeff": "quqd8_3113",
+      "comment": "# Cquqd83x1x1x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        1
+      ],
+      "coeff": "quqd8_3121",
+      "comment": "# Cquqd83x1x2x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        2
+      ],
+      "coeff": "quqd8_3122",
+      "comment": "# Cquqd83x1x2x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        3
+      ],
+      "coeff": "quqd8_3123",
+      "comment": "# Cquqd83x1x2x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        1
+      ],
+      "coeff": "quqd8_3131",
+      "comment": "# Cquqd83x1x3x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        2
+      ],
+      "coeff": "quqd8_3132",
+      "comment": "# Cquqd83x1x3x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        3
+      ],
+      "coeff": "quqd8_3133",
+      "comment": "# Cquqd83x1x3x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        1
+      ],
+      "coeff": "quqd8_3211",
+      "comment": "# Cquqd83x2x1x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        2
+      ],
+      "coeff": "quqd8_3212",
+      "comment": "# Cquqd83x2x1x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        3
+      ],
+      "coeff": "quqd8_3213",
+      "comment": "# Cquqd83x2x1x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        1
+      ],
+      "coeff": "quqd8_3221",
+      "comment": "# Cquqd83x2x2x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        2
+      ],
+      "coeff": "quqd8_3222",
+      "comment": "# Cquqd83x2x2x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        3
+      ],
+      "coeff": "quqd8_3223",
+      "comment": "# Cquqd83x2x2x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "coeff": "quqd8_3231",
+      "comment": "# Cquqd83x2x3x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        2
+      ],
+      "coeff": "quqd8_3232",
+      "comment": "# Cquqd83x2x3x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        3
+      ],
+      "coeff": "quqd8_3233",
+      "comment": "# Cquqd83x2x3x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        1
+      ],
+      "coeff": "quqd8_3311",
+      "comment": "# Cquqd83x3x1x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        2
+      ],
+      "coeff": "quqd8_3312",
+      "comment": "# Cquqd83x3x1x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        3
+      ],
+      "coeff": "quqd8_3313",
+      "comment": "# Cquqd83x3x1x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        1
+      ],
+      "coeff": "quqd8_3321",
+      "comment": "# Cquqd83x3x2x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        2
+      ],
+      "coeff": "quqd8_3322",
+      "comment": "# Cquqd83x3x2x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        3
+      ],
+      "coeff": "quqd8_3323",
+      "comment": "# Cquqd83x3x2x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        1
+      ],
+      "coeff": "quqd8_3331",
+      "comment": "# Cquqd83x3x3x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        2
+      ],
+      "coeff": "quqd8_3332",
+      "comment": "# Cquqd83x3x3x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        3
+      ],
+      "coeff": "quqd8_3333",
+      "comment": "# Cquqd83x3x3x3 "
+    }
+  ],
+  "frblock5": [
+    {
+      "index": [
+        1,
+        1
+      ],
+      "coeff": "dG_11",
+      "comment": "# CdG1x1 "
+    },
+    {
+      "index": [
+        1,
+        2
+      ],
+      "coeff": "dG_12",
+      "comment": "# CdG1x2 "
+    },
+    {
+      "index": [
+        1,
+        3
+      ],
+      "coeff": "dG_13",
+      "comment": "# CdG1x3 "
+    },
+    {
+      "index": [
+        2,
+        1
+      ],
+      "coeff": "dG_21",
+      "comment": "# CdG2x1 "
+    },
+    {
+      "index": [
+        2,
+        2
+      ],
+      "coeff": "dG_22",
+      "comment": "# CdG2x2 "
+    },
+    {
+      "index": [
+        2,
+        3
+      ],
+      "coeff": "dG_23",
+      "comment": "# CdG2x3 "
+    },
+    {
+      "index": [
+        3,
+        1
+      ],
+      "coeff": "dG_31",
+      "comment": "# CdG3x1 "
+    },
+    {
+      "index": [
+        3,
+        2
+      ],
+      "coeff": "dG_32",
+      "comment": "# CdG3x2 "
+    },
+    {
+      "index": [
+        3,
+        3
+      ],
+      "coeff": "dG_33",
+      "comment": "# CdG3x3 "
+    }
+  ],
+  "frblock50": [
+    {
+      "index": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "coeff": "ud1_1111",
+      "comment": "# Cud11x1x1x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        2
+      ],
+      "coeff": "ud1_1112",
+      "comment": "# Cud11x1x1x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        3
+      ],
+      "coeff": "ud1_1113",
+      "comment": "# Cud11x1x1x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        1
+      ],
+      "coeff": "ud1_1121",
+      "comment": "# Cud11x1x2x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "coeff": "ud1_1122",
+      "comment": "# Cud11x1x2x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "coeff": "ud1_1123",
+      "comment": "# Cud11x1x2x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        1
+      ],
+      "coeff": "ud1_1131",
+      "comment": "# Cud11x1x3x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        2
+      ],
+      "coeff": "ud1_1132",
+      "comment": "# Cud11x1x3x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        3
+      ],
+      "coeff": "ud1_1133",
+      "comment": "# Cud11x1x3x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        1
+      ],
+      "coeff": "ud1_1211",
+      "comment": "# Cud11x2x1x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        2
+      ],
+      "coeff": "ud1_1212",
+      "comment": "# Cud11x2x1x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        3
+      ],
+      "coeff": "ud1_1213",
+      "comment": "# Cud11x2x1x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        1
+      ],
+      "coeff": "ud1_1221",
+      "comment": "# Cud11x2x2x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        2
+      ],
+      "coeff": "ud1_1222",
+      "comment": "# Cud11x2x2x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        3
+      ],
+      "coeff": "ud1_1223",
+      "comment": "# Cud11x2x2x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        1
+      ],
+      "coeff": "ud1_1231",
+      "comment": "# Cud11x2x3x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        2
+      ],
+      "coeff": "ud1_1232",
+      "comment": "# Cud11x2x3x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        3
+      ],
+      "coeff": "ud1_1233",
+      "comment": "# Cud11x2x3x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        1
+      ],
+      "coeff": "ud1_1311",
+      "comment": "# Cud11x3x1x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        2
+      ],
+      "coeff": "ud1_1312",
+      "comment": "# Cud11x3x1x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        3
+      ],
+      "coeff": "ud1_1313",
+      "comment": "# Cud11x3x1x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        1
+      ],
+      "coeff": "ud1_1321",
+      "comment": "# Cud11x3x2x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        2
+      ],
+      "coeff": "ud1_1322",
+      "comment": "# Cud11x3x2x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        3
+      ],
+      "coeff": "ud1_1323",
+      "comment": "# Cud11x3x2x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        1
+      ],
+      "coeff": "ud1_1331",
+      "comment": "# Cud11x3x3x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        2
+      ],
+      "coeff": "ud1_1332",
+      "comment": "# Cud11x3x3x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        3
+      ],
+      "coeff": "ud1_1333",
+      "comment": "# Cud11x3x3x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "coeff": "ud1_2111",
+      "comment": "# Cud12x1x1x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        2
+      ],
+      "coeff": "ud1_2112",
+      "comment": "# Cud12x1x1x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        3
+      ],
+      "coeff": "ud1_2113",
+      "comment": "# Cud12x1x1x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "coeff": "ud1_2121",
+      "comment": "# Cud12x1x2x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        2
+      ],
+      "coeff": "ud1_2122",
+      "comment": "# Cud12x1x2x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "coeff": "ud1_2123",
+      "comment": "# Cud12x1x2x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        1
+      ],
+      "coeff": "ud1_2131",
+      "comment": "# Cud12x1x3x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        2
+      ],
+      "coeff": "ud1_2132",
+      "comment": "# Cud12x1x3x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        3
+      ],
+      "coeff": "ud1_2133",
+      "comment": "# Cud12x1x3x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        1
+      ],
+      "coeff": "ud1_2211",
+      "comment": "# Cud12x2x1x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        2
+      ],
+      "coeff": "ud1_2212",
+      "comment": "# Cud12x2x1x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        3
+      ],
+      "coeff": "ud1_2213",
+      "comment": "# Cud12x2x1x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        1
+      ],
+      "coeff": "ud1_2221",
+      "comment": "# Cud12x2x2x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "coeff": "ud1_2222",
+      "comment": "# Cud12x2x2x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        3
+      ],
+      "coeff": "ud1_2223",
+      "comment": "# Cud12x2x2x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        1
+      ],
+      "coeff": "ud1_2231",
+      "comment": "# Cud12x2x3x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        2
+      ],
+      "coeff": "ud1_2232",
+      "comment": "# Cud12x2x3x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        3
+      ],
+      "coeff": "ud1_2233",
+      "comment": "# Cud12x2x3x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        1
+      ],
+      "coeff": "ud1_2311",
+      "comment": "# Cud12x3x1x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        2
+      ],
+      "coeff": "ud1_2312",
+      "comment": "# Cud12x3x1x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        3
+      ],
+      "coeff": "ud1_2313",
+      "comment": "# Cud12x3x1x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        1
+      ],
+      "coeff": "ud1_2321",
+      "comment": "# Cud12x3x2x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        2
+      ],
+      "coeff": "ud1_2322",
+      "comment": "# Cud12x3x2x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        3
+      ],
+      "coeff": "ud1_2323",
+      "comment": "# Cud12x3x2x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        1
+      ],
+      "coeff": "ud1_2331",
+      "comment": "# Cud12x3x3x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        2
+      ],
+      "coeff": "ud1_2332",
+      "comment": "# Cud12x3x3x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        3
+      ],
+      "coeff": "ud1_2333",
+      "comment": "# Cud12x3x3x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        1
+      ],
+      "coeff": "ud1_3111",
+      "comment": "# Cud13x1x1x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        2
+      ],
+      "coeff": "ud1_3112",
+      "comment": "# Cud13x1x1x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        3
+      ],
+      "coeff": "ud1_3113",
+      "comment": "# Cud13x1x1x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        1
+      ],
+      "coeff": "ud1_3121",
+      "comment": "# Cud13x1x2x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        2
+      ],
+      "coeff": "ud1_3122",
+      "comment": "# Cud13x1x2x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        3
+      ],
+      "coeff": "ud1_3123",
+      "comment": "# Cud13x1x2x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        1
+      ],
+      "coeff": "ud1_3131",
+      "comment": "# Cud13x1x3x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        2
+      ],
+      "coeff": "ud1_3132",
+      "comment": "# Cud13x1x3x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        3
+      ],
+      "coeff": "ud1_3133",
+      "comment": "# Cud13x1x3x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        1
+      ],
+      "coeff": "ud1_3211",
+      "comment": "# Cud13x2x1x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        2
+      ],
+      "coeff": "ud1_3212",
+      "comment": "# Cud13x2x1x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        3
+      ],
+      "coeff": "ud1_3213",
+      "comment": "# Cud13x2x1x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        1
+      ],
+      "coeff": "ud1_3221",
+      "comment": "# Cud13x2x2x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        2
+      ],
+      "coeff": "ud1_3222",
+      "comment": "# Cud13x2x2x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        3
+      ],
+      "coeff": "ud1_3223",
+      "comment": "# Cud13x2x2x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "coeff": "ud1_3231",
+      "comment": "# Cud13x2x3x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        2
+      ],
+      "coeff": "ud1_3232",
+      "comment": "# Cud13x2x3x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        3
+      ],
+      "coeff": "ud1_3233",
+      "comment": "# Cud13x2x3x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        1
+      ],
+      "coeff": "ud1_3311",
+      "comment": "# Cud13x3x1x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        2
+      ],
+      "coeff": "ud1_3312",
+      "comment": "# Cud13x3x1x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        3
+      ],
+      "coeff": "ud1_3313",
+      "comment": "# Cud13x3x1x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        1
+      ],
+      "coeff": "ud1_3321",
+      "comment": "# Cud13x3x2x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        2
+      ],
+      "coeff": "ud1_3322",
+      "comment": "# Cud13x3x2x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        3
+      ],
+      "coeff": "ud1_3323",
+      "comment": "# Cud13x3x2x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        1
+      ],
+      "coeff": "ud1_3331",
+      "comment": "# Cud13x3x3x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        2
+      ],
+      "coeff": "ud1_3332",
+      "comment": "# Cud13x3x3x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        3
+      ],
+      "coeff": "ud1_3333",
+      "comment": "# Cud13x3x3x3 "
+    }
+  ],
+  "frblock51": [
+    {
+      "index": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "coeff": "ud8_1111",
+      "comment": "# Cud81x1x1x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        2
+      ],
+      "coeff": "ud8_1112",
+      "comment": "# Cud81x1x1x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        3
+      ],
+      "coeff": "ud8_1113",
+      "comment": "# Cud81x1x1x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        1
+      ],
+      "coeff": "ud8_1121",
+      "comment": "# Cud81x1x2x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "coeff": "ud8_1122",
+      "comment": "# Cud81x1x2x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "coeff": "ud8_1123",
+      "comment": "# Cud81x1x2x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        1
+      ],
+      "coeff": "ud8_1131",
+      "comment": "# Cud81x1x3x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        2
+      ],
+      "coeff": "ud8_1132",
+      "comment": "# Cud81x1x3x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        3
+      ],
+      "coeff": "ud8_1133",
+      "comment": "# Cud81x1x3x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        1
+      ],
+      "coeff": "ud8_1211",
+      "comment": "# Cud81x2x1x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        2
+      ],
+      "coeff": "ud8_1212",
+      "comment": "# Cud81x2x1x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        3
+      ],
+      "coeff": "ud8_1213",
+      "comment": "# Cud81x2x1x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        1
+      ],
+      "coeff": "ud8_1221",
+      "comment": "# Cud81x2x2x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        2
+      ],
+      "coeff": "ud8_1222",
+      "comment": "# Cud81x2x2x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        3
+      ],
+      "coeff": "ud8_1223",
+      "comment": "# Cud81x2x2x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        1
+      ],
+      "coeff": "ud8_1231",
+      "comment": "# Cud81x2x3x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        2
+      ],
+      "coeff": "ud8_1232",
+      "comment": "# Cud81x2x3x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        3
+      ],
+      "coeff": "ud8_1233",
+      "comment": "# Cud81x2x3x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        1
+      ],
+      "coeff": "ud8_1311",
+      "comment": "# Cud81x3x1x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        2
+      ],
+      "coeff": "ud8_1312",
+      "comment": "# Cud81x3x1x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        3
+      ],
+      "coeff": "ud8_1313",
+      "comment": "# Cud81x3x1x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        1
+      ],
+      "coeff": "ud8_1321",
+      "comment": "# Cud81x3x2x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        2
+      ],
+      "coeff": "ud8_1322",
+      "comment": "# Cud81x3x2x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        3
+      ],
+      "coeff": "ud8_1323",
+      "comment": "# Cud81x3x2x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        1
+      ],
+      "coeff": "ud8_1331",
+      "comment": "# Cud81x3x3x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        2
+      ],
+      "coeff": "ud8_1332",
+      "comment": "# Cud81x3x3x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        3
+      ],
+      "coeff": "ud8_1333",
+      "comment": "# Cud81x3x3x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "coeff": "ud8_2111",
+      "comment": "# Cud82x1x1x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        2
+      ],
+      "coeff": "ud8_2112",
+      "comment": "# Cud82x1x1x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        3
+      ],
+      "coeff": "ud8_2113",
+      "comment": "# Cud82x1x1x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "coeff": "ud8_2121",
+      "comment": "# Cud82x1x2x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        2
+      ],
+      "coeff": "ud8_2122",
+      "comment": "# Cud82x1x2x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "coeff": "ud8_2123",
+      "comment": "# Cud82x1x2x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        1
+      ],
+      "coeff": "ud8_2131",
+      "comment": "# Cud82x1x3x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        2
+      ],
+      "coeff": "ud8_2132",
+      "comment": "# Cud82x1x3x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        3
+      ],
+      "coeff": "ud8_2133",
+      "comment": "# Cud82x1x3x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        1
+      ],
+      "coeff": "ud8_2211",
+      "comment": "# Cud82x2x1x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        2
+      ],
+      "coeff": "ud8_2212",
+      "comment": "# Cud82x2x1x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        3
+      ],
+      "coeff": "ud8_2213",
+      "comment": "# Cud82x2x1x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        1
+      ],
+      "coeff": "ud8_2221",
+      "comment": "# Cud82x2x2x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "coeff": "ud8_2222",
+      "comment": "# Cud82x2x2x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        3
+      ],
+      "coeff": "ud8_2223",
+      "comment": "# Cud82x2x2x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        1
+      ],
+      "coeff": "ud8_2231",
+      "comment": "# Cud82x2x3x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        2
+      ],
+      "coeff": "ud8_2232",
+      "comment": "# Cud82x2x3x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        3
+      ],
+      "coeff": "ud8_2233",
+      "comment": "# Cud82x2x3x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        1
+      ],
+      "coeff": "ud8_2311",
+      "comment": "# Cud82x3x1x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        2
+      ],
+      "coeff": "ud8_2312",
+      "comment": "# Cud82x3x1x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        3
+      ],
+      "coeff": "ud8_2313",
+      "comment": "# Cud82x3x1x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        1
+      ],
+      "coeff": "ud8_2321",
+      "comment": "# Cud82x3x2x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        2
+      ],
+      "coeff": "ud8_2322",
+      "comment": "# Cud82x3x2x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        3
+      ],
+      "coeff": "ud8_2323",
+      "comment": "# Cud82x3x2x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        1
+      ],
+      "coeff": "ud8_2331",
+      "comment": "# Cud82x3x3x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        2
+      ],
+      "coeff": "ud8_2332",
+      "comment": "# Cud82x3x3x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        3
+      ],
+      "coeff": "ud8_2333",
+      "comment": "# Cud82x3x3x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        1
+      ],
+      "coeff": "ud8_3111",
+      "comment": "# Cud83x1x1x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        2
+      ],
+      "coeff": "ud8_3112",
+      "comment": "# Cud83x1x1x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        3
+      ],
+      "coeff": "ud8_3113",
+      "comment": "# Cud83x1x1x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        1
+      ],
+      "coeff": "ud8_3121",
+      "comment": "# Cud83x1x2x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        2
+      ],
+      "coeff": "ud8_3122",
+      "comment": "# Cud83x1x2x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        3
+      ],
+      "coeff": "ud8_3123",
+      "comment": "# Cud83x1x2x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        1
+      ],
+      "coeff": "ud8_3131",
+      "comment": "# Cud83x1x3x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        2
+      ],
+      "coeff": "ud8_3132",
+      "comment": "# Cud83x1x3x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        3
+      ],
+      "coeff": "ud8_3133",
+      "comment": "# Cud83x1x3x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        1
+      ],
+      "coeff": "ud8_3211",
+      "comment": "# Cud83x2x1x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        2
+      ],
+      "coeff": "ud8_3212",
+      "comment": "# Cud83x2x1x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        3
+      ],
+      "coeff": "ud8_3213",
+      "comment": "# Cud83x2x1x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        1
+      ],
+      "coeff": "ud8_3221",
+      "comment": "# Cud83x2x2x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        2
+      ],
+      "coeff": "ud8_3222",
+      "comment": "# Cud83x2x2x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        3
+      ],
+      "coeff": "ud8_3223",
+      "comment": "# Cud83x2x2x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "coeff": "ud8_3231",
+      "comment": "# Cud83x2x3x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        2
+      ],
+      "coeff": "ud8_3232",
+      "comment": "# Cud83x2x3x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        3
+      ],
+      "coeff": "ud8_3233",
+      "comment": "# Cud83x2x3x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        1
+      ],
+      "coeff": "ud8_3311",
+      "comment": "# Cud83x3x1x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        2
+      ],
+      "coeff": "ud8_3312",
+      "comment": "# Cud83x3x1x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        3
+      ],
+      "coeff": "ud8_3313",
+      "comment": "# Cud83x3x1x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        1
+      ],
+      "coeff": "ud8_3321",
+      "comment": "# Cud83x3x2x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        2
+      ],
+      "coeff": "ud8_3322",
+      "comment": "# Cud83x3x2x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        3
+      ],
+      "coeff": "ud8_3323",
+      "comment": "# Cud83x3x2x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        1
+      ],
+      "coeff": "ud8_3331",
+      "comment": "# Cud83x3x3x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        2
+      ],
+      "coeff": "ud8_3332",
+      "comment": "# Cud83x3x3x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        3
+      ],
+      "coeff": "ud8_3333",
+      "comment": "# Cud83x3x3x3 "
+    }
+  ],
+  "frblock52": [
+    {
+      "index": [
+        1,
+        1,
+        1,
+        1
+      ],
+      "coeff": "uu_1111",
+      "comment": "# Cuu1x1x1x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        2
+      ],
+      "coeff": "uu_1112",
+      "comment": "# Cuu1x1x1x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        1,
+        3
+      ],
+      "coeff": "uu_1113",
+      "comment": "# Cuu1x1x1x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        1
+      ],
+      "coeff": "uu_1121",
+      "comment": "# Cuu1x1x2x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        2
+      ],
+      "coeff": "uu_1122",
+      "comment": "# Cuu1x1x2x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "coeff": "uu_1123",
+      "comment": "# Cuu1x1x2x3 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        1
+      ],
+      "coeff": "uu_1131",
+      "comment": "# Cuu1x1x3x1 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        2
+      ],
+      "coeff": "uu_1132",
+      "comment": "# Cuu1x1x3x2 "
+    },
+    {
+      "index": [
+        1,
+        1,
+        3,
+        3
+      ],
+      "coeff": "uu_1133",
+      "comment": "# Cuu1x1x3x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        1
+      ],
+      "coeff": "uu_1211",
+      "comment": "# Cuu1x2x1x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        2
+      ],
+      "coeff": "uu_1212",
+      "comment": "# Cuu1x2x1x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        1,
+        3
+      ],
+      "coeff": "uu_1213",
+      "comment": "# Cuu1x2x1x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        1
+      ],
+      "coeff": "uu_1221",
+      "comment": "# Cuu1x2x2x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        2
+      ],
+      "coeff": "uu_1222",
+      "comment": "# Cuu1x2x2x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        2,
+        3
+      ],
+      "coeff": "uu_1223",
+      "comment": "# Cuu1x2x2x3 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        1
+      ],
+      "coeff": "uu_1231",
+      "comment": "# Cuu1x2x3x1 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        2
+      ],
+      "coeff": "uu_1232",
+      "comment": "# Cuu1x2x3x2 "
+    },
+    {
+      "index": [
+        1,
+        2,
+        3,
+        3
+      ],
+      "coeff": "uu_1233",
+      "comment": "# Cuu1x2x3x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        1
+      ],
+      "coeff": "uu_1311",
+      "comment": "# Cuu1x3x1x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        2
+      ],
+      "coeff": "uu_1312",
+      "comment": "# Cuu1x3x1x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        1,
+        3
+      ],
+      "coeff": "uu_1313",
+      "comment": "# Cuu1x3x1x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        1
+      ],
+      "coeff": "uu_1321",
+      "comment": "# Cuu1x3x2x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        2
+      ],
+      "coeff": "uu_1322",
+      "comment": "# Cuu1x3x2x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        2,
+        3
+      ],
+      "coeff": "uu_1323",
+      "comment": "# Cuu1x3x2x3 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        1
+      ],
+      "coeff": "uu_1331",
+      "comment": "# Cuu1x3x3x1 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        2
+      ],
+      "coeff": "uu_1332",
+      "comment": "# Cuu1x3x3x2 "
+    },
+    {
+      "index": [
+        1,
+        3,
+        3,
+        3
+      ],
+      "coeff": "uu_1333",
+      "comment": "# Cuu1x3x3x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "coeff": "uu_2111",
+      "comment": "# Cuu2x1x1x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        2
+      ],
+      "coeff": "uu_2112",
+      "comment": "# Cuu2x1x1x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        1,
+        3
+      ],
+      "coeff": "uu_2113",
+      "comment": "# Cuu2x1x1x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "coeff": "uu_2121",
+      "comment": "# Cuu2x1x2x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        2
+      ],
+      "coeff": "uu_2122",
+      "comment": "# Cuu2x1x2x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "coeff": "uu_2123",
+      "comment": "# Cuu2x1x2x3 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        1
+      ],
+      "coeff": "uu_2131",
+      "comment": "# Cuu2x1x3x1 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        2
+      ],
+      "coeff": "uu_2132",
+      "comment": "# Cuu2x1x3x2 "
+    },
+    {
+      "index": [
+        2,
+        1,
+        3,
+        3
+      ],
+      "coeff": "uu_2133",
+      "comment": "# Cuu2x1x3x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        1
+      ],
+      "coeff": "uu_2211",
+      "comment": "# Cuu2x2x1x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        2
+      ],
+      "coeff": "uu_2212",
+      "comment": "# Cuu2x2x1x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        1,
+        3
+      ],
+      "coeff": "uu_2213",
+      "comment": "# Cuu2x2x1x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        1
+      ],
+      "coeff": "uu_2221",
+      "comment": "# Cuu2x2x2x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "coeff": "uu_2222",
+      "comment": "# Cuu2x2x2x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        2,
+        3
+      ],
+      "coeff": "uu_2223",
+      "comment": "# Cuu2x2x2x3 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        1
+      ],
+      "coeff": "uu_2231",
+      "comment": "# Cuu2x2x3x1 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        2
+      ],
+      "coeff": "uu_2232",
+      "comment": "# Cuu2x2x3x2 "
+    },
+    {
+      "index": [
+        2,
+        2,
+        3,
+        3
+      ],
+      "coeff": "uu_2233",
+      "comment": "# Cuu2x2x3x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        1
+      ],
+      "coeff": "uu_2311",
+      "comment": "# Cuu2x3x1x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        2
+      ],
+      "coeff": "uu_2312",
+      "comment": "# Cuu2x3x1x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        1,
+        3
+      ],
+      "coeff": "uu_2313",
+      "comment": "# Cuu2x3x1x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        1
+      ],
+      "coeff": "uu_2321",
+      "comment": "# Cuu2x3x2x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        2
+      ],
+      "coeff": "uu_2322",
+      "comment": "# Cuu2x3x2x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        2,
+        3
+      ],
+      "coeff": "uu_2323",
+      "comment": "# Cuu2x3x2x3 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        1
+      ],
+      "coeff": "uu_2331",
+      "comment": "# Cuu2x3x3x1 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        2
+      ],
+      "coeff": "uu_2332",
+      "comment": "# Cuu2x3x3x2 "
+    },
+    {
+      "index": [
+        2,
+        3,
+        3,
+        3
+      ],
+      "coeff": "uu_2333",
+      "comment": "# Cuu2x3x3x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        1
+      ],
+      "coeff": "uu_3111",
+      "comment": "# Cuu3x1x1x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        2
+      ],
+      "coeff": "uu_3112",
+      "comment": "# Cuu3x1x1x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        1,
+        3
+      ],
+      "coeff": "uu_3113",
+      "comment": "# Cuu3x1x1x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        1
+      ],
+      "coeff": "uu_3121",
+      "comment": "# Cuu3x1x2x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        2
+      ],
+      "coeff": "uu_3122",
+      "comment": "# Cuu3x1x2x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        2,
+        3
+      ],
+      "coeff": "uu_3123",
+      "comment": "# Cuu3x1x2x3 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        1
+      ],
+      "coeff": "uu_3131",
+      "comment": "# Cuu3x1x3x1 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        2
+      ],
+      "coeff": "uu_3132",
+      "comment": "# Cuu3x1x3x2 "
+    },
+    {
+      "index": [
+        3,
+        1,
+        3,
+        3
+      ],
+      "coeff": "uu_3133",
+      "comment": "# Cuu3x1x3x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        1
+      ],
+      "coeff": "uu_3211",
+      "comment": "# Cuu3x2x1x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        2
+      ],
+      "coeff": "uu_3212",
+      "comment": "# Cuu3x2x1x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        1,
+        3
+      ],
+      "coeff": "uu_3213",
+      "comment": "# Cuu3x2x1x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        1
+      ],
+      "coeff": "uu_3221",
+      "comment": "# Cuu3x2x2x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        2
+      ],
+      "coeff": "uu_3222",
+      "comment": "# Cuu3x2x2x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        2,
+        3
+      ],
+      "coeff": "uu_3223",
+      "comment": "# Cuu3x2x2x3 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "coeff": "uu_3231",
+      "comment": "# Cuu3x2x3x1 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        2
+      ],
+      "coeff": "uu_3232",
+      "comment": "# Cuu3x2x3x2 "
+    },
+    {
+      "index": [
+        3,
+        2,
+        3,
+        3
+      ],
+      "coeff": "uu_3233",
+      "comment": "# Cuu3x2x3x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        1
+      ],
+      "coeff": "uu_3311",
+      "comment": "# Cuu3x3x1x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        2
+      ],
+      "coeff": "uu_3312",
+      "comment": "# Cuu3x3x1x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        1,
+        3
+      ],
+      "coeff": "uu_3313",
+      "comment": "# Cuu3x3x1x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        1
+      ],
+      "coeff": "uu_3321",
+      "comment": "# Cuu3x3x2x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        2
+      ],
+      "coeff": "uu_3322",
+      "comment": "# Cuu3x3x2x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        2,
+        3
+      ],
+      "coeff": "uu_3323",
+      "comment": "# Cuu3x3x2x3 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        1
+      ],
+      "coeff": "uu_3331",
+      "comment": "# Cuu3x3x3x1 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        2
+      ],
+      "coeff": "uu_3332",
+      "comment": "# Cuu3x3x3x2 "
+    },
+    {
+      "index": [
+        3,
+        3,
+        3,
+        3
+      ],
+      "coeff": "uu_3333",
+      "comment": "# Cuu3x3x3x3 "
+    }
+  ],
+  "frblock6": [
+    {
+      "index": [
+        1,
+        1
+      ],
+      "coeff": "dphi_11",
+      "comment": "# Cdphi1x1 "
+    },
+    {
+      "index": [
+        1,
+        2
+      ],
+      "coeff": "dphi_12",
+      "comment": "# Cdphi1x2 "
+    },
+    {
+      "index": [
+        1,
+        3
+      ],
+      "coeff": "dphi_13",
+      "comment": "# Cdphi1x3 "
+    },
+    {
+      "index": [
+        2,
+        1
+      ],
+      "coeff": "dphi_21",
+      "comment": "# Cdphi2x1 "
+    },
+    {
+      "index": [
+        2,
+        2
+      ],
+      "coeff": "dphi_22",
+      "comment": "# Cdphi2x2 "
+    },
+    {
+      "index": [
+        2,
+        3
+      ],
+      "coeff": "dphi_23",
+      "comment": "# Cdphi2x3 "
+    },
+    {
+      "index": [
+        3,
+        1
+      ],
+      "coeff": "dphi_31",
+      "comment": "# Cdphi3x1 "
+    },
+    {
+      "index": [
+        3,
+        2
+      ],
+      "coeff": "dphi_32",
+      "comment": "# Cdphi3x2 "
+    },
+    {
+      "index": [
+        3,
+        3
+      ],
+      "coeff": "dphi_33",
+      "comment": "# Cdphi3x3 "
+    }
+  ],
+  "frblock7": [
+    {
+      "index": [
+        1,
+        1
+      ],
+      "coeff": "dW_11",
+      "comment": "# CdW1x1 "
+    },
+    {
+      "index": [
+        1,
+        2
+      ],
+      "coeff": "dW_12",
+      "comment": "# CdW1x2 "
+    },
+    {
+      "index": [
+        1,
+        3
+      ],
+      "coeff": "dW_13",
+      "comment": "# CdW1x3 "
+    },
+    {
+      "index": [
+        2,
+        1
+      ],
+      "coeff": "dW_21",
+      "comment": "# CdW2x1 "
+    },
+    {
+      "index": [
+        2,
+        2
+      ],
+      "coeff": "dW_22",
+      "comment": "# CdW2x2 "
+    },
+    {
+      "index": [
+        2,
+        3
+      ],
+      "coeff": "dW_23",
+      "comment": "# CdW2x3 "
+    },
+    {
+      "index": [
+        3,
+        1
+      ],
+      "coeff": "dW_31",
+      "comment": "# CdW3x1 "
+    },
+    {
+      "index": [
+        3,
+        2
+      ],
+      "coeff": "dW_32",
+      "comment": "# CdW3x2 "
+    },
+    {
+      "index": [
+        3,
+        3
+      ],
+      "coeff": "dW_33",
+      "comment": "# CdW3x3 "
+    }
+  ],
+  "frblock8": [
+    {
+      "index": [
+        1,
+        1
+      ],
+      "coeff": "eB_11",
+      "comment": "# CeB1x1 "
+    },
+    {
+      "index": [
+        1,
+        2
+      ],
+      "coeff": "eB_12",
+      "comment": "# CeB1x2 "
+    },
+    {
+      "index": [
+        1,
+        3
+      ],
+      "coeff": "eB_13",
+      "comment": "# CeB1x3 "
+    },
+    {
+      "index": [
+        2,
+        1
+      ],
+      "coeff": "eB_21",
+      "comment": "# CeB2x1 "
+    },
+    {
+      "index": [
+        2,
+        2
+      ],
+      "coeff": "eB_22",
+      "comment": "# CeB2x2 "
+    },
+    {
+      "index": [
+        2,
+        3
+      ],
+      "coeff": "eB_23",
+      "comment": "# CeB2x3 "
+    },
+    {
+      "index": [
+        3,
+        1
+      ],
+      "coeff": "eB_31",
+      "comment": "# CeB3x1 "
+    },
+    {
+      "index": [
+        3,
+        2
+      ],
+      "coeff": "eB_32",
+      "comment": "# CeB3x2 "
+    },
+    {
+      "index": [
+        3,
+        3
+      ],
+      "coeff": "eB_33",
+      "comment": "# CeB3x3 "
+    }
+  ],
+  "frblock9": [
+    {
+      "index": [
+        1,
+        1
+      ],
+      "coeff": "ephi_11",
+      "comment": "# Cephi1x1 "
+    },
+    {
+      "index": [
+        1,
+        2
+      ],
+      "coeff": "ephi_12",
+      "comment": "# Cephi1x2 "
+    },
+    {
+      "index": [
+        1,
+        3
+      ],
+      "coeff": "ephi_13",
+      "comment": "# Cephi1x3 "
+    },
+    {
+      "index": [
+        2,
+        1
+      ],
+      "coeff": "ephi_21",
+      "comment": "# Cephi2x1 "
+    },
+    {
+      "index": [
+        2,
+        2
+      ],
+      "coeff": "ephi_22",
+      "comment": "# Cephi2x2 "
+    },
+    {
+      "index": [
+        2,
+        3
+      ],
+      "coeff": "ephi_23",
+      "comment": "# Cephi2x3 "
+    },
+    {
+      "index": [
+        3,
+        1
+      ],
+      "coeff": "ephi_31",
+      "comment": "# Cephi3x1 "
+    },
+    {
+      "index": [
+        3,
+        2
+      ],
+      "coeff": "ephi_32",
+      "comment": "# Cephi3x2 "
+    },
+    {
+      "index": [
+        3,
+        3
+      ],
+      "coeff": "ephi_33",
+      "comment": "# Cephi3x3 "
+    }
+  ]
+}


### PR DESCRIPTION
This is the first version of a converter script to convert WCxf files to `param_card.dat` files for SmeftFR, just like in the case of SMEFTsim. Usage:

```
wcxf2smeftfr my_wcxf.json --output param_card.dat
```